### PR TITLE
:ambulance:fix:Increase password field length from 30 to 60

### DIFF
--- a/src/main/java/excluz/excluz/common/entity/Streamer.java
+++ b/src/main/java/excluz/excluz/common/entity/Streamer.java
@@ -1,5 +1,6 @@
 package excluz.excluz.common.entity;
 
+import excluz.excluz.domain.user.enums.UserRole;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -34,7 +35,7 @@ public class Streamer extends BaseEntity {
 	@Column(nullable = false, unique = true, length = 50)
 	private String email;
 
-	@Column(nullable = false, length = 30)
+	@Column(nullable = false, length = 60)
 	private String password;
 
 	@Enumerated(EnumType.STRING)


### PR DESCRIPTION
## 목적
password field의 length 수정

## 변경점
Bcrypt로 해싱된 비밀번호의 길이가 60자라서
streamer Entity의 password field의 length를 60으로 수정