### PR TITLE
:sparkles: feat: Implement add item to cart functionality

### DIFF
--- a/src/main/java/excluz/excluz/common/entity/CartItem.java
+++ b/src/main/java/excluz/excluz/common/entity/CartItem.java
@@ -48,10 +48,10 @@ public class CartItem extends BaseEntity{
 
 	// 개수
 	@Column(name = "quantity", nullable = false)
-	private int quantity;
+	private Integer quantity;
 
 	// 매개변수 4개 미만일 때는 직접 생성자 추가
-	public CartItem(User user, Item item, int quantity) {
+	public CartItem(User user, Item item, Integer quantity) {
 		this.user = user;
 		this.item = item;
 		this.quantity = quantity;

--- a/src/main/java/excluz/excluz/common/entity/Streamer.java
+++ b/src/main/java/excluz/excluz/common/entity/Streamer.java
@@ -1,5 +1,6 @@
 package excluz.excluz.common.entity;
 
+import excluz.excluz.domain.user.enums.UserRole;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;

--- a/src/main/java/excluz/excluz/common/exception/error/ErrorResponseDto.java
+++ b/src/main/java/excluz/excluz/common/exception/error/ErrorResponseDto.java
@@ -7,7 +7,6 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
-@AllArgsConstructor
 @RequiredArgsConstructor
 public class ErrorResponseDto {
 	private final HttpStatus httpStatus;

--- a/src/main/java/excluz/excluz/common/exception/error/ErrorResponseDto.java
+++ b/src/main/java/excluz/excluz/common/exception/error/ErrorResponseDto.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
+@AllArgsConstructor
 @RequiredArgsConstructor
 public class ErrorResponseDto {
 	private final HttpStatus httpStatus;

--- a/src/main/java/excluz/excluz/domain/cartItem/controller/CartItemController.java
+++ b/src/main/java/excluz/excluz/domain/cartItem/controller/CartItemController.java
@@ -1,9 +1,17 @@
 package excluz.excluz.domain.cartItem.controller;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import excluz.excluz.domain.cartItem.dto.request.CreateCartItemRequestDto;
+import excluz.excluz.domain.cartItem.dto.response.CreateCartItemResponseDto;
 import excluz.excluz.domain.cartItem.service.CartItemService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -11,4 +19,17 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class CartItemController {
 	private final CartItemService cartItemService;
+
+	// 물품 추가
+	@PostMapping("/v1/cart-items")
+	public ResponseEntity<CreateCartItemResponseDto> addItemToCart(
+		@RequestHeader Integer userId,
+		@Valid @RequestBody CreateCartItemRequestDto requestDto
+	) {
+		// 서비스단으로 userId와 리퀘스트 정보 넘기기
+		CreateCartItemResponseDto response = cartItemService.addItemToCart(userId, requestDto);
+
+		// HTTP 상태 코드 201(create)와 함께 CreateCartItemResponseDto 응답
+		return new ResponseEntity<>(response, HttpStatus.CREATED);
+	}
 }

--- a/src/main/java/excluz/excluz/domain/cartItem/controller/CartItemController.java
+++ b/src/main/java/excluz/excluz/domain/cartItem/controller/CartItemController.java
@@ -4,13 +4,14 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import excluz.excluz.domain.cartItem.dto.request.CreateCartItemRequestDto;
 import excluz.excluz.domain.cartItem.dto.response.CreateCartItemResponseDto;
 import excluz.excluz.domain.cartItem.service.CartItemService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -23,9 +24,12 @@ public class CartItemController {
 	// 물품 추가
 	@PostMapping("/v1/cart-items")
 	public ResponseEntity<CreateCartItemResponseDto> addItemToCart(
-		@RequestHeader Integer userId,
+		HttpServletRequest request,
 		@Valid @RequestBody CreateCartItemRequestDto requestDto
 	) {
+		// JWT를 통해 인증된 유저의 ID를 request의 attribute에서 가져옴
+		Integer userId = (Integer) request.getAttribute("userId");
+
 		// 서비스단으로 userId와 리퀘스트 정보 넘기기
 		CreateCartItemResponseDto response = cartItemService.addItemToCart(userId, requestDto);
 

--- a/src/main/java/excluz/excluz/domain/cartItem/controller/CartItemController.java
+++ b/src/main/java/excluz/excluz/domain/cartItem/controller/CartItemController.java
@@ -11,7 +11,6 @@ import excluz.excluz.domain.cartItem.dto.request.CreateCartItemRequestDto;
 import excluz.excluz.domain.cartItem.dto.response.CreateCartItemResponseDto;
 import excluz.excluz.domain.cartItem.service.CartItemService;
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/excluz/excluz/domain/cartItem/dto/request/CreateCartItemRequestDto.java
+++ b/src/main/java/excluz/excluz/domain/cartItem/dto/request/CreateCartItemRequestDto.java
@@ -1,4 +1,21 @@
 package excluz.excluz.domain.cartItem.dto.request;
 
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
 public class CreateCartItemRequestDto {
+	@NotNull(message = "아이템 ID는 필수입니다.")
+	private Integer itemId;
+
+	@Min(value = 1, message = "수량은 1 이상이어야 합니다.")
+	private Integer quantity;
+
+	public CreateCartItemRequestDto(Integer itemId, Integer quantity) {
+		this.itemId = itemId;
+		this.quantity = quantity;
+	}
 }

--- a/src/main/java/excluz/excluz/domain/cartItem/dto/response/CreateCartItemResponseDto.java
+++ b/src/main/java/excluz/excluz/domain/cartItem/dto/response/CreateCartItemResponseDto.java
@@ -1,4 +1,12 @@
 package excluz.excluz.domain.cartItem.dto.response;
 
+import lombok.Getter;
+
+@Getter
 public class CreateCartItemResponseDto {
+	private final String message;
+
+	public CreateCartItemResponseDto() {
+		this.message = "장바구니에 굿즈가 담겼습니다.";
+	}
 }

--- a/src/main/java/excluz/excluz/domain/cartItem/service/CartItemService.java
+++ b/src/main/java/excluz/excluz/domain/cartItem/service/CartItemService.java
@@ -8,6 +8,7 @@ import excluz.excluz.common.entity.User;
 import excluz.excluz.domain.cartItem.dto.request.CreateCartItemRequestDto;
 import excluz.excluz.domain.cartItem.dto.response.CreateCartItemResponseDto;
 import excluz.excluz.domain.cartItem.repository.CartItemRepository;
+import excluz.excluz.domain.store.item.repository.ItemRepository;
 import excluz.excluz.domain.user.repository.UserRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -17,6 +18,7 @@ import lombok.RequiredArgsConstructor;
 public class CartItemService {
 	private final CartItemRepository cartItemRepository;
 	private final UserRepository userRepository;
+	private final ItemRepository itemRepository;
 
 	// 물품 추가
 	@Transactional

--- a/src/main/java/excluz/excluz/domain/cartItem/service/CartItemService.java
+++ b/src/main/java/excluz/excluz/domain/cartItem/service/CartItemService.java
@@ -2,11 +2,34 @@ package excluz.excluz.domain.cartItem.service;
 
 import org.springframework.stereotype.Service;
 
+import excluz.excluz.common.entity.CartItem;
+import excluz.excluz.common.entity.Item;
+import excluz.excluz.common.entity.User;
+import excluz.excluz.domain.cartItem.dto.request.CreateCartItemRequestDto;
+import excluz.excluz.domain.cartItem.dto.response.CreateCartItemResponseDto;
 import excluz.excluz.domain.cartItem.repository.CartItemRepository;
+import excluz.excluz.domain.user.repository.UserRepository;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 public class CartItemService {
 	private final CartItemRepository cartItemRepository;
+	private final UserRepository userRepository;
+
+	// 물품 추가
+	@Transactional
+	public CreateCartItemResponseDto addItemToCart(Integer userId, CreateCartItemRequestDto requestDto) {
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new IllegalArgumentException("해당 유저가 존재하지 않습니다."));
+		Item item = itemRepository.findById(requestDto.getItemId())
+			.orElseThrow(() -> new IllegalArgumentException("해당 아이템이 존재하지 않습니다."));
+
+		CartItem cartItem = new CartItem(user, item, requestDto.getQuantity());
+		cartItemRepository.save(cartItem);
+
+		return new CreateCartItemResponseDto();
+	}
+
 }

--- a/src/main/java/excluz/excluz/domain/cartItem/service/CartItemService.java
+++ b/src/main/java/excluz/excluz/domain/cartItem/service/CartItemService.java
@@ -5,6 +5,8 @@ import org.springframework.stereotype.Service;
 import excluz.excluz.common.entity.CartItem;
 import excluz.excluz.common.entity.Item;
 import excluz.excluz.common.entity.User;
+import excluz.excluz.common.exception.NotFoundException;
+import excluz.excluz.common.exception.error.ErrorCode;
 import excluz.excluz.domain.cartItem.dto.request.CreateCartItemRequestDto;
 import excluz.excluz.domain.cartItem.dto.response.CreateCartItemResponseDto;
 import excluz.excluz.domain.cartItem.repository.CartItemRepository;
@@ -24,9 +26,9 @@ public class CartItemService {
 	@Transactional
 	public CreateCartItemResponseDto addItemToCart(Integer userId, CreateCartItemRequestDto requestDto) {
 		User user = userRepository.findById(userId)
-			.orElseThrow(() -> new IllegalArgumentException("해당 유저가 존재하지 않습니다."));
+			.orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND));
 		Item item = itemRepository.findById(requestDto.getItemId())
-			.orElseThrow(() -> new IllegalArgumentException("해당 아이템이 존재하지 않습니다."));
+			.orElseThrow(() -> new NotFoundException(ErrorCode.ITEM_NOT_FOUND));
 
 		CartItem cartItem = new CartItem(user, item, requestDto.getQuantity());
 		cartItemRepository.save(cartItem);


### PR DESCRIPTION
## 목적
장바구니에 물품 추가 기능 구현
예외 처리 개선, 불필요한 import 문 정리

## 변경점
### 장바구니 아이템 기능 개선
- CartItemService에서 ItemRepository 의존성 추가하여 아이템 조회 기능을 개선함
- CartItemService에서 예외 처리 방식 변경 (IllegalArgumentException → NotFoundException)

### 예외 처리 개선
- 커스텀익셉션 적용

### 불필요한 코드 정리
- CartItemController에서 사용되지 않는 import 문 제거
- Streamer 엔티티에서 UserRole import 추가

### 기타 수정 사항
- ErrorResponseDto에서 @AllArgsConstructor 제거하여 생성자 중복 문제 해결
- CartItem의 quantity 타입을 int에서 Integer로 변경