### PR TITLE
✨ feat:Add Core Logic(Applicant, Drawing, Confirmed)

### DIFF
--- a/src/main/java/excluz/excluz/common/entity/Event.java
+++ b/src/main/java/excluz/excluz/common/entity/Event.java
@@ -3,10 +3,7 @@ package excluz.excluz.common.entity;
 import excluz.excluz.domain.event.event.enums.ParticipantCondition;
 import excluz.excluz.domain.event.event.enums.SelectionMethod;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
@@ -47,8 +44,12 @@ public class Event extends BaseEntity  {
     @Column(name = "end_datetime",  nullable = false)
     private LocalDateTime endDatetime;
 
+    // 이벤트 마감 여부
     @Column(name = "is_completed",  nullable = false)
     private Boolean isCompleted;
+
+    @Column(name = "is_deleted",  nullable = false)
+    private Boolean isDeleted;
 
 
     // 생성자: 매개변수 4개 이상이므로 @Builder 패턴 사용
@@ -59,8 +60,7 @@ public class Event extends BaseEntity  {
                  ParticipantCondition participantCondition,
                  SelectionMethod selectionMethod,
                  LocalDateTime startDatetime,
-                 LocalDateTime endDatetime,
-                 Boolean isCompleted) {
+                 LocalDateTime endDatetime) {
         this.store = store;
         this.numberOfWinners = numberOfWinners;
         this.generatedCode = generatedCode;
@@ -68,7 +68,8 @@ public class Event extends BaseEntity  {
         this.selectionMethod = selectionMethod;
         this.startDatetime = startDatetime;
         this.endDatetime = endDatetime;
-        this.isCompleted = isCompleted;
+        this.isCompleted = false;
+        this.isDeleted = false;
     }
 
     public void updateNumberOfWinners(Integer numberOfWinners) {

--- a/src/main/java/excluz/excluz/common/entity/EventApplicant.java
+++ b/src/main/java/excluz/excluz/common/entity/EventApplicant.java
@@ -3,10 +3,7 @@ package excluz.excluz.common.entity;
 
 import excluz.excluz.domain.event.eventApplicant.enums.ApplicantStatus;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 

--- a/src/main/java/excluz/excluz/common/entity/EventApplicant.java
+++ b/src/main/java/excluz/excluz/common/entity/EventApplicant.java
@@ -26,21 +26,21 @@ public class EventApplicant extends BaseEntity  {
     @JoinColumn(name = "event_id", nullable = false)
     private Event event;
 
-    @Column(name = "applicant_name", length = 10, nullable = false)
-    private String applicantName;
-
     @Column(name = "email", length = 50, unique = true, nullable = false)
     private String email;
+
+    @Column(name = "applicant_name", length = 10, nullable = false)
+    private String applicantName;
 
     @Column(name = "applicant_password", length = 30, nullable = false)
     private String applicantPassword;
 
+    @Column(name = "delivery_address", length = 100, nullable = false)
+    private String deliveryAddress;
+
     @Enumerated(EnumType.STRING)
     @Column(name = "applicant_status", nullable = false)
     private ApplicantStatus applicantStatus;
-
-    @Column(name = "delivery_address", length = 100, nullable = false)
-    private String deliveryAddress;
 
 
     // 생성자: 매개변수 4개 이상이므로 @Builder 패턴 사용
@@ -49,14 +49,14 @@ public class EventApplicant extends BaseEntity  {
                           String applicantName,
                           String email,
                           String applicantPassword,
-                          ApplicantStatus applicantStatus,
-                          String deliveryAddress) {
+                          String deliveryAddress,
+                          ApplicantStatus applicantStatus) {
         this.event = event;
         this.applicantName = applicantName;
         this.email = email;
         this.applicantPassword = applicantPassword;
-        this.applicantStatus = applicantStatus;
         this.deliveryAddress = deliveryAddress;
+        this.applicantStatus = applicantStatus;
     }
 
     // Setter 대신 필요한 필드에 대한 개별 메서드 생성

--- a/src/main/java/excluz/excluz/domain/event/event/controller/EventController.java
+++ b/src/main/java/excluz/excluz/domain/event/event/controller/EventController.java
@@ -1,6 +1,7 @@
 package excluz.excluz.domain.event.event.controller;
 
 import excluz.excluz.common.entity.Event;
+import excluz.excluz.domain.event.event.dto.EventClosingResponseDto;
 import excluz.excluz.domain.event.event.dto.EventRequestDto;
 import excluz.excluz.domain.event.event.dto.EventResponseDto;
 import excluz.excluz.domain.event.event.service.EventService;
@@ -18,7 +19,6 @@ public class EventController {
 
     private final EventService eventService;
 
-    // 예약 생성 API
     @PostMapping()
     public ResponseEntity<EventResponseDto> createEvent(@RequestBody EventRequestDto eventRequestDto) {
 //        todo: 유저인증로직
@@ -26,7 +26,6 @@ public class EventController {
         return ResponseEntity.status(201).body(eventResponseDto);
     }
 
-    // 이벤트 전체 조회 API
     @GetMapping()
     public ResponseEntity<List<EventResponseDto>> getAllEvents() {
         // todo: 유저인증로직
@@ -34,11 +33,17 @@ public class EventController {
         return ResponseEntity.ok(eventResponseDtoList);
     }
 
-    // 이벤트 단건 조회 API
     @GetMapping("/{eventId}")
     public ResponseEntity<EventResponseDto> getEvent(@PathVariable Integer eventId) {
         // todo: 유저인증로직
         EventResponseDto eventResponseDto = eventService.getEvent(eventId);
         return ResponseEntity.ok(eventResponseDto);
+    }
+
+    @PatchMapping("/{eventId}/applicants")
+    public ResponseEntity<EventClosingResponseDto> closeEvent(@PathVariable Integer eventId) {
+        // todo: 유저인증로직
+        EventClosingResponseDto eventClosingResponseDto = eventService.closeEvent(eventId);
+        return ResponseEntity.ok(eventClosingResponseDto);
     }
 }

--- a/src/main/java/excluz/excluz/domain/event/event/dto/EventClosingResponseDto.java
+++ b/src/main/java/excluz/excluz/domain/event/event/dto/EventClosingResponseDto.java
@@ -1,0 +1,88 @@
+package excluz.excluz.domain.event.event.dto;
+
+import excluz.excluz.common.entity.Event;
+import excluz.excluz.common.entity.EventApplicant;
+import excluz.excluz.common.entity.EventItem;
+import excluz.excluz.domain.event.eventApplicant.dto.EventApplicantResponseDto;
+import excluz.excluz.domain.event.eventItem.dto.EventItemDto;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@NoArgsConstructor
+public class EventClosingResponseDto {
+    private Integer id;
+    private Integer storeId;
+    private Integer numberOfWinners;
+    private String participantCondition;
+    private String selectionMethod;
+    private LocalDateTime startDatetime;
+    private LocalDateTime endDatetime;
+    private Boolean isCompleted;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private String generatedCode;
+    private List<EventItemDto> eventItems;
+    private List<EventApplicantResponseDto> eventApplicants; // 응모자 정보 추가
+
+    @Builder
+    public EventClosingResponseDto(Integer id,
+                                   Integer storeId,
+                                   Integer numberOfWinners,
+                                   String generatedCode,
+                                   String participantCondition,
+                                   String selectionMethod,
+                                   LocalDateTime startDatetime,
+                                   LocalDateTime endDatetime,
+                                   Boolean isCompleted,
+                                   List<EventItemDto> eventItems,
+                                   List<EventApplicantResponseDto> eventApplicants) {
+        this.id = id;
+        this.storeId = storeId;
+        this.numberOfWinners = numberOfWinners;
+        this.generatedCode = generatedCode;
+        this.participantCondition = participantCondition;
+        this.selectionMethod = selectionMethod;
+        this.startDatetime = startDatetime;
+        this.endDatetime = endDatetime;
+        this.isCompleted = isCompleted;
+        this.eventItems = eventItems;
+        this.eventApplicants = eventApplicants;
+    }
+
+    // 응모자 정보를 포함하여 응답 DTO 생성하는 메서드
+    public static EventClosingResponseDto from(Event event, List<EventItem> eventItems, List<EventApplicant> eventApplicants) {
+        List<EventItemDto> eventItemDtos = null;
+        if (eventItems != null) {
+            eventItemDtos = eventItems.stream()
+                    .map(EventItemDto::from)
+                    .collect(Collectors.toList());
+        }
+
+        List<EventApplicantResponseDto> applicantDtos = null;
+        if (eventApplicants != null) {
+            applicantDtos = eventApplicants.stream()
+                    .map(EventApplicantResponseDto::from)
+                    .collect(Collectors.toList());
+        }
+
+        return EventClosingResponseDto.builder()
+                .id(event.getId())
+                .storeId(event.getStore().getId())
+                .numberOfWinners(event.getNumberOfWinners())
+                .generatedCode(event.getGeneratedCode())
+                .participantCondition(event.getParticipantCondition().name())
+                .selectionMethod(event.getSelectionMethod().name())
+                .startDatetime(event.getStartDatetime())
+                .endDatetime(event.getEndDatetime())
+                .isCompleted(event.getIsCompleted())
+                .eventItems(eventItemDtos)
+                .eventApplicants(applicantDtos)
+                .build();
+    }
+}

--- a/src/main/java/excluz/excluz/domain/event/event/repository/EventRepository.java
+++ b/src/main/java/excluz/excluz/domain/event/event/repository/EventRepository.java
@@ -3,6 +3,8 @@ package excluz.excluz.domain.event.event.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import excluz.excluz.common.entity.Event;
 
-public interface EventRepository extends JpaRepository<Event, Integer> {
+import java.util.Optional;
 
+public interface EventRepository extends JpaRepository<Event, Integer> {
+    Optional<Event> findByGeneratedCode(String generatedCode);
 }

--- a/src/main/java/excluz/excluz/domain/event/event/service/EventService.java
+++ b/src/main/java/excluz/excluz/domain/event/event/service/EventService.java
@@ -1,13 +1,13 @@
 package excluz.excluz.domain.event.event.service;
 
-import excluz.excluz.common.entity.EventItem;
-import excluz.excluz.common.entity.Item;
+import excluz.excluz.common.entity.*;
+import excluz.excluz.domain.event.event.dto.EventClosingResponseDto;
+import excluz.excluz.domain.event.eventApplicant.enums.ApplicantStatus;
+import excluz.excluz.domain.event.eventApplicant.repository.EventApplicantRepository;
 import excluz.excluz.domain.event.eventItem.dto.EventItemRequestDto;
 import excluz.excluz.domain.event.eventItem.repository.EventItemRepository;
 import excluz.excluz.domain.store.item.repository.ItemRepository;
 import excluz.excluz.domain.store.store.repository.StoreRepository;
-import excluz.excluz.common.entity.Event;
-import excluz.excluz.common.entity.Store;
 import excluz.excluz.domain.event.event.dto.EventRequestDto;
 import excluz.excluz.domain.event.event.enums.ParticipantCondition;
 import excluz.excluz.domain.event.event.enums.SelectionMethod;
@@ -19,6 +19,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -31,8 +33,9 @@ public class EventService {
     private final EventRepository eventRepository;
     private final EventItemRepository eventItemRepository;
     private final ItemRepository itemRepository;
+    private final EventApplicantRepository eventApplicantRepository;
 
-
+    //todo: 추후 temp 수정
     public EventResponseDto createEvent(EventRequestDto eventRequestDto) {
         // 이벤트 생성 비즈니스 로직 구현
         Store store = storeRepository.findById(eventRequestDto.getStoreId())
@@ -46,7 +49,6 @@ public class EventService {
                 .selectionMethod(SelectionMethod.valueOf(eventRequestDto.getSelectionMethod()))
                 .startDatetime(eventRequestDto.getStartDatetime())
                 .endDatetime(eventRequestDto.getEndDatetime())
-                .isCompleted(false) // 초기값 설정
                 .generatedCode(generateUniqueCode()) // 고유 코드 생성 로직 필요
                 .build();
 
@@ -109,9 +111,72 @@ public class EventService {
         return EventResponseDto.fromWithItems(event, eventItems);
     }
 
+    // 이벤트 마감 메서드 추가
+    public EventClosingResponseDto closeEvent(Integer eventId) {
+        Event event = eventRepository.findById(eventId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 이벤트를 찾을 수 없습니다. ID: " + eventId));
+
+        if (event.getIsCompleted()) {
+            throw new IllegalStateException("이미 마감된 이벤트입니다.");
+        }
+
+        // 이벤트 응모자 조회
+        List<EventApplicant> applicantList = eventApplicantRepository.findByEvent(event);
+
+        if (applicantList.isEmpty()) {
+            throw new IllegalStateException("해당 이벤트에 응모자가 없습니다.");
+        }
+
+        // 당첨자 선정 로직
+        int numberOfWinners = event.getNumberOfWinners();
+        if (event.getSelectionMethod() == SelectionMethod.RANDOM_DRAW) {
+            // 무작위 추첨
+            Collections.shuffle(applicantList);
+            List<EventApplicant> winners = applicantList.subList(0, Math.min(numberOfWinners, applicantList.size()));
+
+            for (EventApplicant applicant : applicantList) {
+                if (winners.contains(applicant)) {
+                    applicant.updateApplicantStatus(ApplicantStatus.WINNER);
+                } else {
+                    applicant.updateApplicantStatus(ApplicantStatus.LOSER);
+                }
+            }
+        } else if (event.getSelectionMethod() == SelectionMethod.FIRST_COME_FIRST_SERVED) {
+            // 선착순
+            applicantList.sort(Comparator.comparing(EventApplicant::getCreatedAt));
+            List<EventApplicant> winners = applicantList.subList(0, Math.min(numberOfWinners, applicantList.size()));
+
+            for (EventApplicant applicant : applicantList) {
+                if (winners.contains(applicant)) {
+                    applicant.updateApplicantStatus(ApplicantStatus.WINNER);
+                } else {
+                    applicant.updateApplicantStatus(ApplicantStatus.LOSER);
+                }
+            }
+        } else {
+            throw new UnsupportedOperationException("지원되지 않는 선정 방식입니다.");
+        }
+
+        event.completeEvent();
+
+        // 변경사항 저장
+        eventRepository.save(event);
+        eventApplicantRepository.saveAll(applicantList);
+
+        // EventItems 조회
+        List<EventItem> eventItems = eventItemRepository.findByEvent(event);
+
+        // 응답 DTO 생성
+        EventClosingResponseDto eventClosingResponseDto = EventClosingResponseDto.from(event, eventItems, applicantList);
+
+        return eventClosingResponseDto;
+    }
+
     private String generateUniqueCode() {
         // 고유 코드 생성 로직 구현
-        return "UNIQUE_CODE";
+        return "UNIQUE_CODE" + eventRepository.count();
     }
+
+
 
 }

--- a/src/main/java/excluz/excluz/domain/event/event/service/EventService.java
+++ b/src/main/java/excluz/excluz/domain/event/event/service/EventService.java
@@ -79,10 +79,11 @@ public class EventService {
 
             // EventItems 저장
             eventItemRepository.saveAll(eventItems);
+            return EventResponseDto.fromWithItems(savedEvent, eventItems);
+        } else {
+            return EventResponseDto.fromWithoutItems(savedEvent);
         }
 
-        // EventResponseDto로 변환하여 반환
-        return EventResponseDto.fromWithItems(savedEvent, eventItems);
     }
 
 

--- a/src/main/java/excluz/excluz/domain/event/eventApplicant/controller/EventApplicantController.java
+++ b/src/main/java/excluz/excluz/domain/event/eventApplicant/controller/EventApplicantController.java
@@ -1,0 +1,29 @@
+package excluz.excluz.domain.event.eventApplicant.controller;
+
+import excluz.excluz.domain.event.eventApplicant.dto.EventApplicantRequestDto;
+import excluz.excluz.domain.event.eventApplicant.dto.EventApplicantResponseDto;
+import excluz.excluz.domain.event.eventApplicant.service.EventApplicantService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/events/applicants")
+@Slf4j
+@RequiredArgsConstructor
+public class EventApplicantController {
+
+    private final EventApplicantService eventApplicantService;
+
+    @PostMapping
+    public EventApplicantResponseDto applyForEvent(@RequestParam("code") String code,
+                                                   @RequestBody EventApplicantRequestDto requestDto) {
+        return eventApplicantService.applyForEvent(code, requestDto);
+    }
+
+    @GetMapping
+    public EventApplicantResponseDto getEventApplication(@RequestParam("code") String code,
+                                                         @RequestBody EventApplicantRequestDto requestDto) {
+        return eventApplicantService.getEventApplication(code, requestDto.getEmail(), requestDto.getApplicantPassword());
+    }
+}

--- a/src/main/java/excluz/excluz/domain/event/eventApplicant/controller/EventApplicantController.java
+++ b/src/main/java/excluz/excluz/domain/event/eventApplicant/controller/EventApplicantController.java
@@ -1,10 +1,12 @@
 package excluz.excluz.domain.event.eventApplicant.controller;
 
+import excluz.excluz.domain.event.event.dto.EventResponseDto;
 import excluz.excluz.domain.event.eventApplicant.dto.EventApplicantRequestDto;
 import excluz.excluz.domain.event.eventApplicant.dto.EventApplicantResponseDto;
 import excluz.excluz.domain.event.eventApplicant.service.EventApplicantService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -18,12 +20,24 @@ public class EventApplicantController {
     @PostMapping
     public EventApplicantResponseDto applyForEvent(@RequestParam("code") String code,
                                                    @RequestBody EventApplicantRequestDto requestDto) {
+        // todo: 유저인증로직
         return eventApplicantService.applyForEvent(code, requestDto);
     }
 
     @GetMapping
     public EventApplicantResponseDto getEventApplication(@RequestParam("code") String code,
                                                          @RequestBody EventApplicantRequestDto requestDto) {
+        // todo: 유저인증로직
         return eventApplicantService.getEventApplication(code, requestDto.getEmail(), requestDto.getApplicantPassword());
     }
+
+    @PatchMapping("/{eventApplicantId}")
+    public ResponseEntity<EventApplicantResponseDto> confirmReceipt(
+            @PathVariable Integer eventApplicantId,
+            @RequestBody EventApplicantRequestDto requestDto) {
+        // todo: 필요한 경우 비회원 인증 여부를 확인할 수도 있음 (예: 비밀번호 체크 등)
+        EventApplicantResponseDto updated = eventApplicantService.confirmReceipt(eventApplicantId, requestDto);
+        return ResponseEntity.ok(updated);
+    }
+
 }

--- a/src/main/java/excluz/excluz/domain/event/eventApplicant/dto/EventApplicantRequestDto.java
+++ b/src/main/java/excluz/excluz/domain/event/eventApplicant/dto/EventApplicantRequestDto.java
@@ -1,4 +1,22 @@
 package excluz.excluz.domain.event.eventApplicant.dto;
 
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
 public class EventApplicantRequestDto {
+    private String email;
+    private String applicantPassword;
+    private String applicantName;
+    private String deliveryAddress;
+
+    @Builder
+    public EventApplicantRequestDto(String email, String applicantName, String applicantPassword, String deliveryAddress) {
+        this.email = email;
+        this.applicantName = applicantName;
+        this.applicantPassword = applicantPassword;
+        this.deliveryAddress = deliveryAddress;
+    }
 }

--- a/src/main/java/excluz/excluz/domain/event/eventApplicant/dto/EventApplicantRequestDto.java
+++ b/src/main/java/excluz/excluz/domain/event/eventApplicant/dto/EventApplicantRequestDto.java
@@ -1,0 +1,4 @@
+package excluz.excluz.domain.event.eventApplicant.dto;
+
+public class EventApplicantRequestDto {
+}

--- a/src/main/java/excluz/excluz/domain/event/eventApplicant/dto/EventApplicantResponseDto.java
+++ b/src/main/java/excluz/excluz/domain/event/eventApplicant/dto/EventApplicantResponseDto.java
@@ -1,4 +1,39 @@
 package excluz.excluz.domain.event.eventApplicant.dto;
 
-public class EventApplicationResponseDto {
+import excluz.excluz.common.entity.EventApplicant;
+import excluz.excluz.domain.event.eventApplicant.enums.ApplicantStatus;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class EventApplicantResponseDto {
+    private Integer id;
+    private Integer eventId;
+    private String email;
+    private String applicantName;
+    private String deliveryAddress;
+    private ApplicantStatus applicantStatus;
+
+    @Builder
+    public EventApplicantResponseDto(Integer id, Integer eventId, String email, String applicantName, ApplicantStatus applicantStatus, String deliveryAddress) {
+        this.id = id;
+        this.eventId = eventId;
+        this.email = email;
+        this.applicantName = applicantName;
+        this.deliveryAddress = deliveryAddress;
+        this.applicantStatus = applicantStatus;
+    }
+
+    public static EventApplicantResponseDto from(EventApplicant eventApplicant) {
+        return EventApplicantResponseDto.builder()
+                .id(eventApplicant.getId())
+                .eventId(eventApplicant.getEvent().getId())
+                .email(eventApplicant.getEmail())
+                .applicantName(eventApplicant.getApplicantName())
+                .deliveryAddress(eventApplicant.getDeliveryAddress())
+                .applicantStatus(eventApplicant.getApplicantStatus())
+                .build();
+    }
 }

--- a/src/main/java/excluz/excluz/domain/event/eventApplicant/dto/EventApplicantResponseDto.java
+++ b/src/main/java/excluz/excluz/domain/event/eventApplicant/dto/EventApplicantResponseDto.java
@@ -1,0 +1,4 @@
+package excluz.excluz.domain.event.eventApplicant.dto;
+
+public class EventApplicationResponseDto {
+}

--- a/src/main/java/excluz/excluz/domain/event/eventApplicant/repository/EventApplicantRepository.java
+++ b/src/main/java/excluz/excluz/domain/event/eventApplicant/repository/EventApplicantRepository.java
@@ -1,7 +1,11 @@
 package excluz.excluz.domain.event.eventApplicant.repository;
 
 import excluz.excluz.common.entity.EventApplicant;
+import excluz.excluz.common.entity.Event;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface EventApplicantRepository extends JpaRepository<EventApplicant, Integer> {
+    Optional<EventApplicant> findByEventAndEmailAndApplicantPassword(Event event, String email, String applicantPassword);
 }

--- a/src/main/java/excluz/excluz/domain/event/eventApplicant/repository/EventApplicantRepository.java
+++ b/src/main/java/excluz/excluz/domain/event/eventApplicant/repository/EventApplicantRepository.java
@@ -4,8 +4,11 @@ import excluz.excluz.common.entity.EventApplicant;
 import excluz.excluz.common.entity.Event;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface EventApplicantRepository extends JpaRepository<EventApplicant, Integer> {
     Optional<EventApplicant> findByEventAndEmailAndApplicantPassword(Event event, String email, String applicantPassword);
+    List<EventApplicant> findByEvent(Event event);
+
 }

--- a/src/main/java/excluz/excluz/domain/event/eventApplicant/service/EventApplicantService.java
+++ b/src/main/java/excluz/excluz/domain/event/eventApplicant/service/EventApplicantService.java
@@ -1,0 +1,50 @@
+package excluz.excluz.domain.event.eventApplicant.service;
+
+
+import excluz.excluz.common.entity.Event;
+import excluz.excluz.common.entity.EventApplicant;
+import excluz.excluz.domain.event.event.repository.EventRepository;
+import excluz.excluz.domain.event.eventApplicant.dto.EventApplicantRequestDto;
+import excluz.excluz.domain.event.eventApplicant.dto.EventApplicantResponseDto;
+import excluz.excluz.domain.event.eventApplicant.enums.ApplicantStatus;
+import excluz.excluz.domain.event.eventApplicant.repository.EventApplicantRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class EventApplicantService {
+
+    private final EventApplicantRepository eventApplicantRepository;
+    private final EventRepository eventRepository;
+
+    public EventApplicantResponseDto applyForEvent(String code, EventApplicantRequestDto requestDto) {
+        Event event = eventRepository.findByGeneratedCode(code)
+                .orElseThrow(() -> new IllegalArgumentException("잘못된 이벤트 코드입니다."));
+
+        EventApplicant eventApplicant = EventApplicant.builder()
+                .event(event)
+                .applicantName(requestDto.getApplicantName())
+                .email(requestDto.getEmail())
+                .applicantPassword(requestDto.getApplicantPassword())
+                .deliveryAddress(requestDto.getDeliveryAddress())
+                .applicantStatus(ApplicantStatus.WAITING) // 초기 상태는 WAITING
+                .build();
+
+        EventApplicant savedApplicant = eventApplicantRepository.save(eventApplicant);
+
+        return EventApplicantResponseDto.from(savedApplicant);
+    }
+
+    public EventApplicantResponseDto getEventApplication(String code, String email, String applicantPassword) {
+        Event event = eventRepository.findByGeneratedCode(code)
+                .orElseThrow(() -> new IllegalArgumentException("잘못된 이벤트 코드입니다."));
+
+        EventApplicant eventApplicant = eventApplicantRepository.findByEventAndEmailAndApplicantPassword(event, email, applicantPassword)
+                .orElseThrow(() -> new IllegalArgumentException("응모 정보를 찾을 수 없거나 잘못된 인증 정보입니다."));
+
+        return EventApplicantResponseDto.from(eventApplicant);
+    }
+}

--- a/src/main/java/excluz/excluz/domain/event/eventApplicant/service/EventApplicantService.java
+++ b/src/main/java/excluz/excluz/domain/event/eventApplicant/service/EventApplicantService.java
@@ -47,4 +47,26 @@ public class EventApplicantService {
 
         return EventApplicantResponseDto.from(eventApplicant);
     }
+
+    public EventApplicantResponseDto confirmReceipt(Integer eventApplicantId, EventApplicantRequestDto requestDto) {
+        EventApplicant eventApplicant = eventApplicantRepository.findById(eventApplicantId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 ID의 응모 정보를 찾을 수 없습니다."));
+
+        if (eventApplicant.getApplicantStatus() != ApplicantStatus.WINNER) {
+            throw new IllegalArgumentException("당첨(WINNER) 상태가 아닌 유저의 수령 확정은 불가능합니다.");
+        }
+
+        if (requestDto.getApplicantName() != null) {
+            eventApplicant.setApplicantName(requestDto.getApplicantName());
+        }
+        if (requestDto.getDeliveryAddress() != null) {
+            eventApplicant.updateDeliveryAddress(requestDto.getDeliveryAddress());
+        }
+
+        eventApplicant.updateApplicantStatus(ApplicantStatus.CONFIRMED);
+
+        EventApplicant updatedApplicant = eventApplicantRepository.save(eventApplicant);
+
+        return EventApplicantResponseDto.from(updatedApplicant);
+    }
 }

--- a/src/main/java/excluz/excluz/domain/event/eventItem/dto/EventItemDto.java
+++ b/src/main/java/excluz/excluz/domain/event/eventItem/dto/EventItemDto.java
@@ -4,7 +4,9 @@ import excluz.excluz.common.entity.Event;
 import excluz.excluz.common.entity.EventItem;
 import excluz.excluz.common.entity.Item;
 import lombok.Builder;
+import lombok.Getter;
 
+@Getter
 public class EventItemDto {
 
     private Integer id;

--- a/src/main/java/excluz/excluz/domain/streamer/repository/StreamerRepository.java
+++ b/src/main/java/excluz/excluz/domain/streamer/repository/StreamerRepository.java
@@ -1,0 +1,4 @@
+package excluz.excluz.domain.streamer.repository;
+
+public class StreamerRepository {
+}

--- a/src/main/java/excluz/excluz/domain/streamer/repository/StreamerRepository.java
+++ b/src/main/java/excluz/excluz/domain/streamer/repository/StreamerRepository.java
@@ -1,4 +1,3 @@
-
 package excluz.excluz.domain.streamer.repository;
 
 import java.util.Optional;

--- a/src/test/java/excluz/excluz/EventApplicantServiceTest.java
+++ b/src/test/java/excluz/excluz/EventApplicantServiceTest.java
@@ -1,0 +1,4 @@
+package excluz.excluz;
+
+public class EventApplicantServiceTest {
+}

--- a/src/test/java/excluz/excluz/EventServiceDBTest.java
+++ b/src/test/java/excluz/excluz/EventServiceDBTest.java
@@ -1,0 +1,4 @@
+package excluz.excluz;
+
+public class EventServiceDBTest {
+}


### PR DESCRIPTION
## 목적
이벤트 핵심 로직(응모, 추첨, 수령 확정) 보강

## 변경점
Event에 is_completed(마감여부) 말고 is_deleted(삭제여부)를 별도로 추가
EventApplicant에서 변수 순서 변경

EventApplicant에 Post(응모), Get(조회), Patch(수령 확정) 로직 추가
Event에 Patch(추첨 마감 및 추첨) 로직 추가 → Applicant 상태 변경
기초 테스트 코드 확인 완료

## 리뷰어에게
이후 dto에 Validate 추가하고, 동시성 제어 로직을 진행할 예정입니다.