### PR TITLE
🚑fix:Modify store deletion logic

### DIFF
--- a/src/main/java/excluz/excluz/domain/store/store/controller/StoreV1Controller.java
+++ b/src/main/java/excluz/excluz/domain/store/store/controller/StoreV1Controller.java
@@ -44,10 +44,11 @@ public class StoreV1Controller {
 	@DeleteMapping("/{storeId}")
 	public ResponseEntity<Void> deleteStore(
 		@AuthenticationPrincipal User user,
+		@PathVariable Integer storeId,
 		@Valid @RequestBody StoreDeleteRequestDto deleteRequestDto
 	) {
 		Integer streamerId = Integer.valueOf(user.getUsername());
-		storeService.deleteStore(deleteRequestDto, streamerId);
+		storeService.deleteStore(deleteRequestDto, streamerId, storeId);
 
 		return new ResponseEntity<>(HttpStatus.NO_CONTENT);
 	}

--- a/src/main/java/excluz/excluz/domain/store/store/controller/StoreV1Controller.java
+++ b/src/main/java/excluz/excluz/domain/store/store/controller/StoreV1Controller.java
@@ -41,7 +41,7 @@ public class StoreV1Controller {
 		return new ResponseEntity<>(HttpStatus.CREATED);
 	}
 
-	@DeleteMapping("/{storeId}")
+	@PatchMapping("/{storeId}/disable")
 	public ResponseEntity<Void> deleteStore(
 		@AuthenticationPrincipal User user,
 		@PathVariable Integer storeId,

--- a/src/main/java/excluz/excluz/domain/store/store/service/StoreService.java
+++ b/src/main/java/excluz/excluz/domain/store/store/service/StoreService.java
@@ -40,14 +40,18 @@ public class StoreService {
 	}
 
 	@Transactional
-	public void deleteStore(StoreDeleteRequestDto deleteRequestDto, Integer streamerId) {
+	public void deleteStore(StoreDeleteRequestDto deleteRequestDto, Integer streamerId, Integer storeId) {
 		Streamer streamer = getStreamerByIdAndNotDeleted(streamerId);
 
 		if (!passwordEncoder.matches(deleteRequestDto.getPassword(), streamer.getPassword())) {
 			throw new BadRequestException(ErrorCode.PASSWORD_MISMATCH);
 		}
 
-		streamer.updateStreamerStatus(true);
+		Store store = storeRepository.findById(storeId).orElseThrow(
+			() -> new NotFoundException(ErrorCode.STORE_NOT_FOUND)
+		);
+
+		store.updateIsDeleted(true);
 	}
 
 	@Transactional

--- a/src/main/java/excluz/excluz/domain/store/store/service/StoreService.java
+++ b/src/main/java/excluz/excluz/domain/store/store/service/StoreService.java
@@ -51,6 +51,10 @@ public class StoreService {
 			() -> new NotFoundException(ErrorCode.STORE_NOT_FOUND)
 		);
 
+		if (store.isDeleted()) {
+			throw new NotFoundException(ErrorCode.STORE_NOT_FOUND);
+		}
+
 		store.updateIsDeleted(true);
 	}
 


### PR DESCRIPTION
## 목적
스토어 삭제 로직 수정

## 변경정
- 스토어 soft delete 로직 추가
(스트리머 soft delete 로직 삭제)
- 매개변수에 storeId 추가
- HTTP 메서드를 patch로 변경
- url을 /api/v1/stores/{storeId}/disable로 수정