### PR TITLE
:white_check_mark: test: Add unit tests and refactor cart item management

### DIFF
--- a/src/main/java/excluz/excluz/domain/cartItem/controller/CartItemController.java
+++ b/src/main/java/excluz/excluz/domain/cartItem/controller/CartItemController.java
@@ -1,6 +1,8 @@
 package excluz.excluz.domain.cartItem.controller;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.User;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -16,7 +18,6 @@ import excluz.excluz.domain.cartItem.dto.response.CartItemListResponseDto;
 import excluz.excluz.domain.cartItem.dto.response.CreateCartItemResponseDto;
 import excluz.excluz.domain.cartItem.dto.response.GetCartItemResponseDto;
 import excluz.excluz.domain.cartItem.service.CartItemService;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -29,12 +30,11 @@ public class CartItemController {
 	// 물품 추가
 	@PostMapping("/v1/cart-items")
 	public ResponseEntity<CreateCartItemResponseDto> addItemToCart(
-		/* TODO JWT 어노테이션 활용으로 수정 예정 */
-		HttpServletRequest request,
+		@AuthenticationPrincipal User user,
 		@Valid @RequestBody CreateCartItemRequestDto requestDto
 	) {
-		/* TODO JWT 토큰에서의 정보 추출 방식 추후 수정 예정 */
-		Integer userId = (Integer) request.getAttribute("userId");
+		// `user.getUsername()`을 사용하여 userId 가져오기
+		Integer userId = Integer.parseInt(user.getUsername());
 
 		// 서비스단으로 userId와 리퀘스트 정보 넘기기
 		CreateCartItemResponseDto response = cartItemService.addItemToCart(userId, requestDto);
@@ -46,12 +46,11 @@ public class CartItemController {
 	// 물품 단건 조회
 	@GetMapping("/v1/cart-items/{cartItemId}")
 	public ResponseEntity<GetCartItemResponseDto> getCartItem(
-		/* TODO JWT 어노테이션 활용으로 수정 예정 */
-		HttpServletRequest request,
+		@AuthenticationPrincipal User user,
 		@PathVariable(name = "cartItemId") Integer cartItemId
 	) {
-		/* TODO JWT 토큰에서의 정보 추출 방식 추후 수정 예정 */
-		Integer userId = (Integer) request.getAttribute("userId");
+		// `user.getUsername()`을 사용하여 userId 가져오기
+		Integer userId = Integer.parseInt(user.getUsername());
 
 		GetCartItemResponseDto response = cartItemService.getCartItem(userId, cartItemId);
 		return ResponseEntity.ok(response);
@@ -60,11 +59,10 @@ public class CartItemController {
 	// 물품 다건 조회
 	@GetMapping("/v1/cart-items")
 	public ResponseEntity<CartItemListResponseDto> getCartItemList(
-		/* TODO JWT 어노테이션 활용으로 수정 예정 */
-		HttpServletRequest request
+		@AuthenticationPrincipal User user
 	) {
-		/* TODO JWT 토큰에서의 정보 추출 방식 추후 수정 예정 */
-		Integer userId = (Integer) request.getAttribute("userId");
+		// `user.getUsername()`을 사용하여 userId 가져오기
+		Integer userId = Integer.parseInt(user.getUsername());
 
 		CartItemListResponseDto response = cartItemService.getCartItemList(userId);
 		return ResponseEntity.ok(response);
@@ -73,13 +71,12 @@ public class CartItemController {
 	// 물품 개수 수정
 	@PatchMapping("/v1/cart-items/{cartItemId}")
 	public ResponseEntity<GetCartItemResponseDto> updateCartItemQuantity(
-		/* TODO JWT 어노테이션 활용으로 수정 예정 */
-		HttpServletRequest request,
+		@AuthenticationPrincipal User user,
 		@PathVariable(name = "cartItemId") Integer cartItemId,
 		@Valid @RequestBody UpdateCartItemQuantityRequestDto requestDto
 	) {
-		/* TODO JWT 토큰에서의 정보 추출 방식 추후 수정 예정 */
-		Integer userId = (Integer) request.getAttribute("userId");
+		// `user.getUsername()`을 사용하여 userId 가져오기
+		Integer userId = Integer.parseInt(user.getUsername());
 
 		GetCartItemResponseDto response = cartItemService.updateCartItemQuantity(userId, cartItemId, requestDto);
 		return ResponseEntity.ok(response);
@@ -88,12 +85,11 @@ public class CartItemController {
 	// 물품 삭제(단건)
 	@DeleteMapping("/v1/cart-items/{cartItemId}")
 	public ResponseEntity<Void> removeCartItem(
-		/* TODO JWT 어노테이션 활용으로 수정 예정 */
-		HttpServletRequest request,
+		@AuthenticationPrincipal User user,
 		@PathVariable(name = "cartItemId") Integer cartItemId
 	) {
-		/* TODO JWT 토큰에서의 정보 추출 방식 추후 수정 예정 */
-		Integer userId = (Integer) request.getAttribute("userId");
+		// `user.getUsername()`을 사용하여 userId 가져오기
+		Integer userId = Integer.parseInt(user.getUsername());
 
 		// cartItemId를 서비스 단으로 넘겨서 검증 및 삭제 진행
 		cartItemService.removeCartItem(userId, cartItemId);

--- a/src/main/java/excluz/excluz/domain/cartItem/repository/CartItemRepository.java
+++ b/src/main/java/excluz/excluz/domain/cartItem/repository/CartItemRepository.java
@@ -13,4 +13,7 @@ public interface CartItemRepository extends JpaRepository<CartItem, Integer> {
 
 	// 특정 유저의 특정 장바구니 아이템 조회(단건 조회)
 	Optional<CartItem> findByIdAndUserId(Integer cartItemId, Integer userId);
+
+	// 특정 유저의 장바구니에 특정 아이템이 있는지 조회(단건 조회)
+	Optional<CartItem> findByUserIdAndItemId(Integer userId, Integer itemId);
 }

--- a/src/main/java/excluz/excluz/domain/cartItem/service/CartItemService.java
+++ b/src/main/java/excluz/excluz/domain/cartItem/service/CartItemService.java
@@ -1,6 +1,7 @@
 package excluz.excluz.domain.cartItem.service;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
@@ -32,7 +33,6 @@ public class CartItemService {
 	// 물품 추가
 	@Transactional
 	public CreateCartItemResponseDto addItemToCart(Integer userId, CreateCartItemRequestDto requestDto) {
-		// todo 추후 의논할 것: CartitemService에서 다른 엔티티의 Repository를 의존하는 구조가 좋은 설계인지 추후에 다같이 고민해보면 좋을 것 같습니다!
 		User user = userRepository.findById(userId)
 			.orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND));
 		Item item = itemRepository.findById(requestDto.getItemId())
@@ -43,8 +43,24 @@ public class CartItemService {
 			throw new BadRequestException(ErrorCode.OUT_OF_STOCK);
 		}
 
-		CartItem cartItem = new CartItem(user, item, requestDto.getQuantity());
-		cartItemRepository.save(cartItem);
+		// 기존 장바구니에서 동일한 상품이 있는지 확인
+		Optional<CartItem> optionalCartItem = cartItemRepository.findByUserIdAndItemId(userId, requestDto.getItemId());
+
+		if (optionalCartItem.isPresent()) {
+			// 이미 장바구니에 있는 경우: 수량 증가
+			CartItem cartItem = optionalCartItem.get();
+			Integer newQuantity = cartItem.getQuantity() + requestDto.getQuantity();
+
+			if (newQuantity > item.getRemainingQuantity()) {
+				throw new BadRequestException(ErrorCode.OUT_OF_STOCK);
+			}
+
+			cartItem.updateQuantity(newQuantity);
+		} else {
+			// 장바구니에 없는 경우: 새로 추가
+			CartItem newCartItem = new CartItem(user, item, requestDto.getQuantity());
+			cartItemRepository.save(newCartItem);
+		}
 
 		return new CreateCartItemResponseDto();
 	}

--- a/src/test/java/excluz/excluz/common/entity/CartItemTest.java
+++ b/src/test/java/excluz/excluz/common/entity/CartItemTest.java
@@ -1,0 +1,21 @@
+package excluz.excluz.common.entity;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class CartItemTest {
+
+	@Test
+	@DisplayName("CartItem의 개수가 잘 업데이트된다.")
+	void updateQuantity() {
+		// given
+		CartItem cartItem = new CartItem(null, null, 10);
+
+		// when
+		cartItem.updateQuantity(9);
+
+		// then
+		Assertions.assertThat(cartItem.getQuantity()).isEqualTo(9);
+	}
+}

--- a/src/test/java/excluz/excluz/common/entity/CartItemTest.java
+++ b/src/test/java/excluz/excluz/common/entity/CartItemTest.java
@@ -10,12 +10,17 @@ class CartItemTest {
 	@DisplayName("CartItem의 개수가 잘 업데이트된다.")
 	void updateQuantity() {
 		// given
-		CartItem cartItem = new CartItem(null, null, 10);
+		CartItem cartItem = new CartItem(
+			null,  // user: null (사용자 정보 없음)
+			null,  // item: null (상품 정보 없음)
+			10     // quantity: 10 (초기 장바구니 속 특정 아이템 개수)
+		);
 
 		// when
-		cartItem.updateQuantity(9);
+		cartItem.updateQuantity(9); // 장바구니 속 특정 아이템 개수를 9로 변경
 
 		// then
-		Assertions.assertThat(cartItem.getQuantity()).isEqualTo(9);
+		Assertions.assertThat(cartItem.getQuantity())
+			.isEqualTo(9);  // expected: 9 (기대한 값)
 	}
 }

--- a/src/test/java/excluz/excluz/domain/cartItem/service/CartItemServiceTest.java
+++ b/src/test/java/excluz/excluz/domain/cartItem/service/CartItemServiceTest.java
@@ -31,16 +31,16 @@ class CartItemServiceTest {
 	void updateCartItemQuantity() {
 		// given
 		Item item = new Item(
-			null,
-			"itemName",
-			"test",
-			100,
-			10
+			null,         // store: null (스토어 정보 없음)
+			"itemName",   // itemName: "itemName" (상품명)
+			"test",       // explanation: "test" (설명)
+			100,          // price: 100 (상품 가격)
+			10            // remainingQuantity: 10 (재고 개수)
 		);
 		CartItem cartItem = new CartItem(
-			null,
-			item,
-			10
+			null,  // user: null (사용자 정보 없음)
+			item,  // item: 위에서 생성한 Item 객체
+			10     // quantity: 10 (현재 장바구니에 담긴 수량)
 		);
 
 		Mockito.when(cartItemRepository.findByIdAndUserId(Mockito.any(), Mockito.any()))
@@ -50,9 +50,9 @@ class CartItemServiceTest {
 
 		// when, then
 		Assertions.assertThatThrownBy(() -> cartItemService.updateCartItemQuantity(
-				null,
-				null,
-				cartItemQuantityRequestDto
+				null,   // user: null (사용자 정보 없음)
+				null,   // cartItem: null (장바구니 아이템 정보 없음)
+				cartItemQuantityRequestDto // 업데이트할 장바구니 아이템 정보
 			))
 			.isInstanceOf(BadRequestException.class);
 	}
@@ -62,16 +62,16 @@ class CartItemServiceTest {
 	void updateCartItemQuantity2() {
 		// given
 		Item item = new Item(
-			null,
-			"itemName",
-			"test",
-			100,
-			11
+			null,         // store: null (스토어 정보 없음)
+			"itemName",   // itemName: "itemName" (상품명)
+			"test",       // explanation: "test" (설명)
+			100,          // price: 100 (상품 가격)
+			11            // remainingQuantity: 11 (재고 개수)
 		);
 		CartItem cartItem = new CartItem(
-			null,
-			item,
-			10
+			null,  // user: null (사용자 정보 없음)
+			item,  // item: 위에서 생성한 Item 객체
+			10     // quantity: 10 (현재 장바구니에 담긴 수량)
 		);
 
 		Mockito.when(cartItemRepository.findByIdAndUserId(Mockito.any(), Mockito.any()))
@@ -81,9 +81,9 @@ class CartItemServiceTest {
 
 		// when, then
 		Assertions.assertThatCode(() -> cartItemService.updateCartItemQuantity(
-				1,
-				1,
-				cartItemQuantityRequestDto
+				null,   // user: null (사용자 정보 없음)
+				null,   // cartItem: null (장바구니 아이템 정보 없음)
+				cartItemQuantityRequestDto // 업데이트할 장바구니 아이템 정보
 			))
 			.doesNotThrowAnyException();
 	}

--- a/src/test/java/excluz/excluz/domain/cartItem/service/CartItemServiceTest.java
+++ b/src/test/java/excluz/excluz/domain/cartItem/service/CartItemServiceTest.java
@@ -56,4 +56,35 @@ class CartItemServiceTest {
 			))
 			.isInstanceOf(BadRequestException.class);
 	}
+
+	@Test
+	@DisplayName("요청된 개수가 재고보다 적은 경우에는 예외가 발생하지 않는다")
+	void updateCartItemQuantity2() {
+		// given
+		Item item = new Item(
+			null,
+			"itemName",
+			"test",
+			100,
+			11
+		);
+		CartItem cartItem = new CartItem(
+			null,
+			item,
+			10
+		);
+
+		Mockito.when(cartItemRepository.findByIdAndUserId(Mockito.any(), Mockito.any()))
+			.thenReturn(Optional.of(cartItem));
+
+		UpdateCartItemQuantityRequestDto cartItemQuantityRequestDto = new UpdateCartItemQuantityRequestDto(1);
+
+		// when, then
+		Assertions.assertThatCode(() -> cartItemService.updateCartItemQuantity(
+				1,
+				1,
+				cartItemQuantityRequestDto
+			))
+			.doesNotThrowAnyException();
+	}
 }

--- a/src/test/java/excluz/excluz/domain/cartItem/service/CartItemServiceTest.java
+++ b/src/test/java/excluz/excluz/domain/cartItem/service/CartItemServiceTest.java
@@ -1,0 +1,59 @@
+package excluz.excluz.domain.cartItem.service;
+
+import java.util.Optional;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import excluz.excluz.common.entity.CartItem;
+import excluz.excluz.common.entity.Item;
+import excluz.excluz.common.exception.BadRequestException;
+import excluz.excluz.domain.cartItem.dto.request.UpdateCartItemQuantityRequestDto;
+import excluz.excluz.domain.cartItem.repository.CartItemRepository;
+
+@ExtendWith(MockitoExtension.class)
+class CartItemServiceTest {
+
+	@Mock
+	private CartItemRepository cartItemRepository;
+
+	@InjectMocks
+	private CartItemService cartItemService;
+
+	@Test
+	@DisplayName("요청된 개수가 재고보다 많은 경우 예외가 발생한다")
+	void updateCartItemQuantity() {
+		// given
+		Item item = new Item(
+			null,
+			"itemName",
+			"test",
+			100,
+			10
+		);
+		CartItem cartItem = new CartItem(
+			null,
+			item,
+			10
+		);
+
+		Mockito.when(cartItemRepository.findByIdAndUserId(Mockito.any(), Mockito.any()))
+			.thenReturn(Optional.of(cartItem));
+
+		UpdateCartItemQuantityRequestDto cartItemQuantityRequestDto = new UpdateCartItemQuantityRequestDto(100);
+
+		// when, then
+		Assertions.assertThatThrownBy(() -> cartItemService.updateCartItemQuantity(
+				null,
+				null,
+				cartItemQuantityRequestDto
+			))
+			.isInstanceOf(BadRequestException.class);
+	}
+}


### PR DESCRIPTION
## 목적
- 장바구니 아이템의 수량 업데이트, 재고 검증 유닛 테스트 추가
- 장바구니 아이템 추가 시 중복 생성 방지, 기존 항목 업데이트하도록 리팩터링
- 사용자 ID 가져오는 방식 변경(@AuthenticationPrincipal 적용)

## 변경점
### 장바구니 아이템 유닛 테스트 추가
- `CartItemTest`: 장바구니 아이템 수량 업데이트 테스트 추가
- `CartItemServiceTest`:
  - 요청된 개수가 재고보다 많은 경우 예외 발생 테스트 추가  
  - 요청된 개수가 재고보다 적거나 같은 경우 정상 동작 테스트 추가  

### 장바구니 아이템 관련 리팩터링  
- 장바구니 아이템 추가 시 중복된 아이템 생성 방지 로직 추가  
- 기존 아이템이 존재할 경우 개수 업데이트하는 방식으로 변경  

### 사용자 ID 추출 방식 변경  
- `@AuthenticationPrincipal` 어노테이션을 활용하여 Spring Security에서 사용자 ID를 직접 가져오도록 변경  

### 기타  
- `CartItemTest` 및 `CartItemServiceTest`에 설명용 주석 추가  
