### PR TITLE
✨ feat: Add user withdrawal API and service logic

### DIFF
--- a/src/main/java/excluz/excluz/common/entity/User.java
+++ b/src/main/java/excluz/excluz/common/entity/User.java
@@ -81,4 +81,15 @@ public class User extends BaseEntity{
 	public void updateUserStatus(Boolean isDeleted) {
 		this.isDeleted = isDeleted;
 	}
+
+	public void updateUserProfile(
+			String nickName,
+			String phoneNumber,
+			String address,
+			String email ) {
+		this.nickName = nickName;
+		this.phoneNumber = phoneNumber;
+		this.address = address;
+		this.email = email;
+	}
 }

--- a/src/main/java/excluz/excluz/common/entity/User.java
+++ b/src/main/java/excluz/excluz/common/entity/User.java
@@ -82,6 +82,10 @@ public class User extends BaseEntity{
 		this.isDeleted = isDeleted;
 	}
 
+	public void updatePassword(String password) {
+		this.password = password;
+	}
+
 	public void updateUserProfile(
 			String nickName,
 			String phoneNumber,

--- a/src/main/java/excluz/excluz/common/exception/error/ErrorCode.java
+++ b/src/main/java/excluz/excluz/common/exception/error/ErrorCode.java
@@ -17,6 +17,7 @@ public enum ErrorCode {
 	INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "이전과 동일한 비밀번호로 수정할 수 없습니다."),
 	PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
 	EMAIL_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 사용중인 이메일입니다."),
+	PASSWORD_RE_ENTER_PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "비밀번호와 재입력 비밀번호가 일치하지 않습니다."),
 
 	// 아이템 관련 예외 코드
 	ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "조회되는 아이템 정보가 없습니다."),

--- a/src/main/java/excluz/excluz/domain/user/controller/UserController.java
+++ b/src/main/java/excluz/excluz/domain/user/controller/UserController.java
@@ -3,7 +3,9 @@ package excluz.excluz.domain.user.controller;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.User;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -13,6 +15,7 @@ import excluz.excluz.domain.user.dto.request.UserLoginRequestDto;
 import excluz.excluz.domain.user.dto.request.UserSignupRequestDto;
 import excluz.excluz.domain.user.dto.request.UserWithdrawRequestDto;
 import excluz.excluz.domain.user.dto.response.UserLoginResponseDto;
+import excluz.excluz.domain.user.dto.response.UserProfileResponseDto;
 import excluz.excluz.domain.user.dto.response.UserSignupResponseDto;
 import excluz.excluz.domain.user.dto.response.UserWithdrawResponseDto;
 import excluz.excluz.domain.user.service.UserService;
@@ -56,5 +59,15 @@ public class UserController {
 		UserWithdrawResponseDto userWithdrawResponseDto = userService.userWithdraw(userId, userWithdrawRequest);
 
 		return ResponseEntity.ok(userWithdrawResponseDto);
+	}
+
+	// 마이페이지가 아닌 다른 유저의 정보 조회
+	@GetMapping("/{userId}")
+	public ResponseEntity<UserProfileResponseDto> userProfileFindAPI(
+		@PathVariable(name = "userId") Integer userId){
+
+		UserProfileResponseDto profileResponseDto = userService.getProfile(userId);
+
+		return ResponseEntity.ok(profileResponseDto);
 	}
 }

--- a/src/main/java/excluz/excluz/domain/user/controller/UserController.java
+++ b/src/main/java/excluz/excluz/domain/user/controller/UserController.java
@@ -7,16 +7,19 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import excluz.excluz.domain.user.dto.UpdatePasswordRequestDto;
 import excluz.excluz.domain.user.dto.request.UpdateMyProfileRequestDto;
 import excluz.excluz.domain.user.dto.request.UserLoginRequestDto;
 import excluz.excluz.domain.user.dto.request.UserSignupRequestDto;
 import excluz.excluz.domain.user.dto.request.UserWithdrawRequestDto;
 import excluz.excluz.domain.user.dto.response.MyProfileResponseDto;
 import excluz.excluz.domain.user.dto.response.UpdateMyProfileResponseDto;
+import excluz.excluz.domain.user.dto.response.UpdatePasswordResponseDto;
 import excluz.excluz.domain.user.dto.response.UserLoginResponseDto;
 import excluz.excluz.domain.user.dto.response.UserProfileResponseDto;
 import excluz.excluz.domain.user.dto.response.UserSignupResponseDto;
@@ -85,7 +88,7 @@ public class UserController {
 	}
 
 	@PatchMapping("/profile")
-	public ResponseEntity<UpdateMyProfileResponseDto> userProfileUpdate(
+	public ResponseEntity<UpdateMyProfileResponseDto> userProfileUpdateAPI(
 		@AuthenticationPrincipal User user,
 		@RequestBody UpdateMyProfileRequestDto updateMyProfileRequest) {
 
@@ -94,5 +97,17 @@ public class UserController {
 		UpdateMyProfileResponseDto updateMyProfileResponse = userService.userUpdateMyProfile(userId, updateMyProfileRequest);
 
 		return ResponseEntity.ok(updateMyProfileResponse);
+	}
+
+	@PutMapping("/password")
+	public ResponseEntity<UpdatePasswordResponseDto> userUpdatePasswordAPU(
+		@AuthenticationPrincipal User user,
+		@RequestBody UpdatePasswordRequestDto updatePasswordRequest) {
+
+		Integer userId = Integer.parseInt(user.getUsername());
+
+		UpdatePasswordResponseDto updatePasswordResponse = userService.userUpdatePassword(userId, updatePasswordRequest);
+
+		return ResponseEntity.ok(updatePasswordResponse);
 	}
 }

--- a/src/main/java/excluz/excluz/domain/user/controller/UserController.java
+++ b/src/main/java/excluz/excluz/domain/user/controller/UserController.java
@@ -11,10 +11,12 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import excluz.excluz.domain.user.dto.request.UpdateMyProfileRequestDto;
 import excluz.excluz.domain.user.dto.request.UserLoginRequestDto;
 import excluz.excluz.domain.user.dto.request.UserSignupRequestDto;
 import excluz.excluz.domain.user.dto.request.UserWithdrawRequestDto;
 import excluz.excluz.domain.user.dto.response.MyProfileResponseDto;
+import excluz.excluz.domain.user.dto.response.UpdateMyProfileResponseDto;
 import excluz.excluz.domain.user.dto.response.UserLoginResponseDto;
 import excluz.excluz.domain.user.dto.response.UserProfileResponseDto;
 import excluz.excluz.domain.user.dto.response.UserSignupResponseDto;
@@ -67,7 +69,7 @@ public class UserController {
 	public ResponseEntity<UserProfileResponseDto> userProfileFindAPI(
 		@PathVariable(name = "userId") Integer userId){
 
-		UserProfileResponseDto profileResponseDto = userService.getProfile(userId);
+		UserProfileResponseDto profileResponseDto = userService.userGetProfile(userId);
 
 		return ResponseEntity.ok(profileResponseDto);
 	}
@@ -77,8 +79,20 @@ public class UserController {
 
 		Integer userId = Integer.parseInt(user.getUsername());
 
-		MyProfileResponseDto myProfileResponse = userService.getMyProfile(userId);
+		MyProfileResponseDto myProfileResponse = userService.userGetMyProfile(userId);
 
 		return ResponseEntity.ok(myProfileResponse);
+	}
+
+	@PatchMapping("/profile")
+	public ResponseEntity<UpdateMyProfileResponseDto> userProfileUpdate(
+		@AuthenticationPrincipal User user,
+		@RequestBody UpdateMyProfileRequestDto updateMyProfileRequest) {
+
+		Integer userId = Integer.parseInt(user.getUsername());
+
+		UpdateMyProfileResponseDto updateMyProfileResponse = userService.userUpdateMyProfile(userId, updateMyProfileRequest);
+
+		return ResponseEntity.ok(updateMyProfileResponse);
 	}
 }

--- a/src/main/java/excluz/excluz/domain/user/controller/UserController.java
+++ b/src/main/java/excluz/excluz/domain/user/controller/UserController.java
@@ -1,6 +1,9 @@
 package excluz.excluz.domain.user.controller;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -8,8 +11,10 @@ import org.springframework.web.bind.annotation.RestController;
 
 import excluz.excluz.domain.user.dto.request.UserLoginRequestDto;
 import excluz.excluz.domain.user.dto.request.UserSignupRequestDto;
+import excluz.excluz.domain.user.dto.request.UserWithdrawRequestDto;
 import excluz.excluz.domain.user.dto.response.UserLoginResponseDto;
 import excluz.excluz.domain.user.dto.response.UserSignupResponseDto;
+import excluz.excluz.domain.user.dto.response.UserWithdrawResponseDto;
 import excluz.excluz.domain.user.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -38,5 +43,18 @@ public class UserController {
 		UserLoginResponseDto userLoginResponseDto = userService.userLogin(loginRequest);
 
 		return ResponseEntity.ok(userLoginResponseDto);
+	}
+
+	@PatchMapping("/withdraw")
+	public ResponseEntity<UserWithdrawResponseDto> userUnregisterAPI(
+		@AuthenticationPrincipal User user,
+		@RequestBody UserWithdrawRequestDto userWithdrawRequest) {
+
+		// 스트링 값으로 저장된 userId를 Integer 로 강제 반환
+		Integer userId = Integer.parseInt(user.getUsername());
+
+		UserWithdrawResponseDto userWithdrawResponseDto = userService.userWithdraw(userId, userWithdrawRequest);
+
+		return ResponseEntity.ok(userWithdrawResponseDto);
 	}
 }

--- a/src/main/java/excluz/excluz/domain/user/controller/UserController.java
+++ b/src/main/java/excluz/excluz/domain/user/controller/UserController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 import excluz.excluz.domain.user.dto.request.UserLoginRequestDto;
 import excluz.excluz.domain.user.dto.request.UserSignupRequestDto;
 import excluz.excluz.domain.user.dto.request.UserWithdrawRequestDto;
+import excluz.excluz.domain.user.dto.response.MyProfileResponseDto;
 import excluz.excluz.domain.user.dto.response.UserLoginResponseDto;
 import excluz.excluz.domain.user.dto.response.UserProfileResponseDto;
 import excluz.excluz.domain.user.dto.response.UserSignupResponseDto;
@@ -69,5 +70,15 @@ public class UserController {
 		UserProfileResponseDto profileResponseDto = userService.getProfile(userId);
 
 		return ResponseEntity.ok(profileResponseDto);
+	}
+
+	@GetMapping("/profile")
+	public ResponseEntity<MyProfileResponseDto> myPageGetAPI(@AuthenticationPrincipal User user) {
+
+		Integer userId = Integer.parseInt(user.getUsername());
+
+		MyProfileResponseDto myProfileResponse = userService.getMyProfile(userId);
+
+		return ResponseEntity.ok(myProfileResponse);
 	}
 }

--- a/src/main/java/excluz/excluz/domain/user/dto/UpdatePasswordRequestDto.java
+++ b/src/main/java/excluz/excluz/domain/user/dto/UpdatePasswordRequestDto.java
@@ -1,0 +1,20 @@
+package excluz.excluz.domain.user.dto;
+
+import lombok.Getter;
+
+@Getter
+public class UpdatePasswordRequestDto {
+
+	private final String oldPassword;
+	private final String newPassword;
+	private final String reEnterPassword;
+
+	public UpdatePasswordRequestDto(
+			String oldPassword,
+			String newPassword,
+			String reEnterPassword) {
+		this.oldPassword = oldPassword;
+		this.newPassword = newPassword;
+		this.reEnterPassword = reEnterPassword;
+	}
+}

--- a/src/main/java/excluz/excluz/domain/user/dto/request/UpdateMyProfileRequestDto.java
+++ b/src/main/java/excluz/excluz/domain/user/dto/request/UpdateMyProfileRequestDto.java
@@ -1,0 +1,28 @@
+package excluz.excluz.domain.user.dto.request;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class UpdateMyProfileRequestDto {
+
+	private final String nickName;
+	private final String phoneNumber;
+	private final String address;
+	private final String email;
+	private final String password;
+
+	@Builder
+	public UpdateMyProfileRequestDto(
+			String nickName,
+			String phoneNumber,
+			String address,
+			String email,
+			String password) {
+		this.nickName = nickName;
+		this.phoneNumber = phoneNumber;
+		this.address = address;
+		this.email = email;
+		this.password = password;
+	}
+}

--- a/src/main/java/excluz/excluz/domain/user/dto/request/UserSignupRequestDto.java
+++ b/src/main/java/excluz/excluz/domain/user/dto/request/UserSignupRequestDto.java
@@ -2,11 +2,11 @@ package excluz.excluz.domain.user.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
-import lombok.Builder;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
-@Builder
+@AllArgsConstructor
 public class UserSignupRequestDto {
 
 	@NotBlank(message = "이름은 필수 입력값 입니다.")
@@ -30,7 +30,7 @@ public class UserSignupRequestDto {
 	@Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{10,30}$", message = "비밀번호는 영문,숫자,특수문자를 포함하여 10자 이상 30자 이내로 작성해 주세요.")
 	private final String password;
 
-	@NotBlank(message = "비밀번호를 다시한번 입력해 주세요.")
+	@NotBlank(message = "비밀번호를 다시 한 번 입력해 주세요.")
 	private final String reEnterPassword;
 
 }

--- a/src/main/java/excluz/excluz/domain/user/dto/request/UserWithdrawRequestDto.java
+++ b/src/main/java/excluz/excluz/domain/user/dto/request/UserWithdrawRequestDto.java
@@ -1,0 +1,15 @@
+package excluz.excluz.domain.user.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class UserWithdrawRequestDto {
+
+	private final String password;
+	private final String reEnterPassword;
+
+	public UserWithdrawRequestDto(String password, String reEnterPassword) {
+		this.password = password;
+		this.reEnterPassword = reEnterPassword;
+	}
+}

--- a/src/main/java/excluz/excluz/domain/user/dto/response/MyProfileResponseDto.java
+++ b/src/main/java/excluz/excluz/domain/user/dto/response/MyProfileResponseDto.java
@@ -1,0 +1,26 @@
+package excluz.excluz.domain.user.dto.response;
+
+import java.time.LocalDateTime;
+
+import excluz.excluz.common.entity.User;
+import lombok.Getter;
+
+@Getter
+public class MyProfileResponseDto {
+
+	private final String name;
+	private final String nickName;
+	private final String email;
+	private final String phoneNumber;
+	private final String address;
+	private final LocalDateTime createdAt;
+
+	public MyProfileResponseDto(User user) {
+		this.name = user.getName();
+		this.nickName = user.getNickName();
+		this.email = user.getEmail();
+		this.phoneNumber = user.getPhoneNumber();
+		this.address = user.getAddress();
+		this.createdAt = user.getCreatedAt();
+	}
+}

--- a/src/main/java/excluz/excluz/domain/user/dto/response/UpdateMyProfileResponseDto.java
+++ b/src/main/java/excluz/excluz/domain/user/dto/response/UpdateMyProfileResponseDto.java
@@ -1,0 +1,20 @@
+package excluz.excluz.domain.user.dto.response;
+
+import java.time.LocalDateTime;
+
+import excluz.excluz.common.entity.User;
+import lombok.Getter;
+
+@Getter
+public class UpdateMyProfileResponseDto {
+
+	private final String message;
+	private final LocalDateTime updatedAt;
+
+	public UpdateMyProfileResponseDto(String message, User user) {
+
+		this.message = message;
+		this.updatedAt = user.getUpdatedAt();
+
+	}
+}

--- a/src/main/java/excluz/excluz/domain/user/dto/response/UpdatePasswordResponseDto.java
+++ b/src/main/java/excluz/excluz/domain/user/dto/response/UpdatePasswordResponseDto.java
@@ -1,0 +1,18 @@
+package excluz.excluz.domain.user.dto.response;
+
+import java.time.LocalDateTime;
+
+import excluz.excluz.common.entity.User;
+import lombok.Getter;
+
+@Getter
+public class UpdatePasswordResponseDto {
+
+	private final String message;
+	private final LocalDateTime updatedAt;
+
+	public UpdatePasswordResponseDto(String message, User user) {
+		this.message = message;
+		this.updatedAt = user.getUpdatedAt();
+	}
+}

--- a/src/main/java/excluz/excluz/domain/user/dto/response/UserProfileResponseDto.java
+++ b/src/main/java/excluz/excluz/domain/user/dto/response/UserProfileResponseDto.java
@@ -1,0 +1,16 @@
+package excluz.excluz.domain.user.dto.response;
+
+import excluz.excluz.common.entity.User;
+import lombok.Getter;
+
+@Getter
+public class UserProfileResponseDto {
+
+	private final String nickName;
+	private final String email;
+
+	public UserProfileResponseDto(User user) {
+		this.nickName = user.getNickName();
+		this.email = user.getEmail();
+	}
+}

--- a/src/main/java/excluz/excluz/domain/user/dto/response/UserWithdrawResponseDto.java
+++ b/src/main/java/excluz/excluz/domain/user/dto/response/UserWithdrawResponseDto.java
@@ -1,0 +1,13 @@
+package excluz.excluz.domain.user.dto.response;
+
+import lombok.Getter;
+
+@Getter
+public class UserWithdrawResponseDto {
+
+	private String message;
+
+	public UserWithdrawResponseDto(String message) {
+		this.message = message;
+	}
+}

--- a/src/main/java/excluz/excluz/domain/user/service/UserService.java
+++ b/src/main/java/excluz/excluz/domain/user/service/UserService.java
@@ -4,6 +4,7 @@ import java.util.Optional;
 
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import excluz.excluz.auth.util.JwtUtil;
 import excluz.excluz.common.entity.User;
@@ -12,8 +13,10 @@ import excluz.excluz.common.exception.NotFoundException;
 import excluz.excluz.common.exception.error.ErrorCode;
 import excluz.excluz.domain.user.dto.request.UserLoginRequestDto;
 import excluz.excluz.domain.user.dto.request.UserSignupRequestDto;
+import excluz.excluz.domain.user.dto.request.UserWithdrawRequestDto;
 import excluz.excluz.domain.user.dto.response.UserLoginResponseDto;
 import excluz.excluz.domain.user.dto.response.UserSignupResponseDto;
+import excluz.excluz.domain.user.dto.response.UserWithdrawResponseDto;
 import excluz.excluz.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 
@@ -74,5 +77,29 @@ public class UserService {
 
 		// 로그인 완료 메세지 및 토큰값 발행
 		return new UserLoginResponseDto("로그인 되었습니다.", token);
+	}
+
+	// 회원탈퇴
+	@Transactional
+	public UserWithdrawResponseDto userWithdraw(
+		Integer userId, UserWithdrawRequestDto userWithdrawRequestDto) {
+
+		// 유저 정보를 userId 로 조회
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND));
+
+		// 리퀘스트 요청에 들어온 비밀번호와 재확인 비밀번호가 일치 하지 않을 시 예외
+		if (!userWithdrawRequestDto.getPassword().equals(userWithdrawRequestDto.getReEnterPassword())) {
+			throw new BadRequestException(ErrorCode.PASSWORD_MISMATCH);
+		}
+
+		// 비밀번호 검증 로직
+		if(!passwordEncoder.matches(userWithdrawRequestDto.getPassword(), user.getPassword())) {
+			throw new BadRequestException(ErrorCode.PASSWORD_MISMATCH);
+		}
+
+		user.updateUserStatus(true);
+
+		return new UserWithdrawResponseDto("회원탈퇴가 완료되었습니다 저희 서비스를 이용해주셔서 감사합니다.");
 	}
 }

--- a/src/main/java/excluz/excluz/domain/user/service/UserService.java
+++ b/src/main/java/excluz/excluz/domain/user/service/UserService.java
@@ -15,6 +15,7 @@ import excluz.excluz.domain.user.dto.request.UserLoginRequestDto;
 import excluz.excluz.domain.user.dto.request.UserSignupRequestDto;
 import excluz.excluz.domain.user.dto.request.UserWithdrawRequestDto;
 import excluz.excluz.domain.user.dto.response.UserLoginResponseDto;
+import excluz.excluz.domain.user.dto.response.UserProfileResponseDto;
 import excluz.excluz.domain.user.dto.response.UserSignupResponseDto;
 import excluz.excluz.domain.user.dto.response.UserWithdrawResponseDto;
 import excluz.excluz.domain.user.repository.UserRepository;
@@ -98,8 +99,25 @@ public class UserService {
 			throw new BadRequestException(ErrorCode.PASSWORD_MISMATCH);
 		}
 
+		// 유저의 isDelete의 상태가 true 가 됨
 		user.updateUserStatus(true);
 
 		return new UserWithdrawResponseDto("회원탈퇴가 완료되었습니다 저희 서비스를 이용해주셔서 감사합니다.");
 	}
+
+	// 유저 조회
+	@Transactional(readOnly = true)
+	public UserProfileResponseDto getProfile(Integer userId) {
+
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND));
+
+		// 탈퇴한 회원 조회시 예외처리
+		if (user.getIsDeleted()) {
+			throw new NotFoundException(ErrorCode.USER_NOT_FOUND);
+		}
+
+		return new UserProfileResponseDto(user);
+	}
+
 }

--- a/src/main/java/excluz/excluz/domain/user/service/UserService.java
+++ b/src/main/java/excluz/excluz/domain/user/service/UserService.java
@@ -11,12 +11,14 @@ import excluz.excluz.common.entity.User;
 import excluz.excluz.common.exception.BadRequestException;
 import excluz.excluz.common.exception.NotFoundException;
 import excluz.excluz.common.exception.error.ErrorCode;
+import excluz.excluz.domain.user.dto.UpdatePasswordRequestDto;
 import excluz.excluz.domain.user.dto.request.UpdateMyProfileRequestDto;
 import excluz.excluz.domain.user.dto.request.UserLoginRequestDto;
 import excluz.excluz.domain.user.dto.request.UserSignupRequestDto;
 import excluz.excluz.domain.user.dto.request.UserWithdrawRequestDto;
 import excluz.excluz.domain.user.dto.response.MyProfileResponseDto;
 import excluz.excluz.domain.user.dto.response.UpdateMyProfileResponseDto;
+import excluz.excluz.domain.user.dto.response.UpdatePasswordResponseDto;
 import excluz.excluz.domain.user.dto.response.UserLoginResponseDto;
 import excluz.excluz.domain.user.dto.response.UserProfileResponseDto;
 import excluz.excluz.domain.user.dto.response.UserSignupResponseDto;
@@ -45,7 +47,7 @@ public class UserService {
 
 		// 리퀘스트 요청에 들어온 비밀번호와 재확인 비밀번호가 일치 하지 않을 시 예외
 		if (!signupRequest.getPassword().equals(signupRequest.getReEnterPassword())) {
-			throw new BadRequestException(ErrorCode.PASSWORD_MISMATCH);
+			throw new BadRequestException(ErrorCode.PASSWORD_RE_ENTER_PASSWORD_MISMATCH);
 		}
 
 		// 비밀번호 해싱 처리
@@ -94,7 +96,7 @@ public class UserService {
 
 		// 리퀘스트 요청에 들어온 비밀번호와 재확인 비밀번호가 일치 하지 않을 시 예외
 		if (!userWithdrawRequest.getPassword().equals(userWithdrawRequest.getReEnterPassword())) {
-			throw new BadRequestException(ErrorCode.PASSWORD_MISMATCH);
+			throw new BadRequestException(ErrorCode.PASSWORD_RE_ENTER_PASSWORD_MISMATCH);
 		}
 
 		// 비밀번호 검증 로직
@@ -152,6 +154,31 @@ public class UserService {
 			updateMyProfileRequest.getEmail()
 			);
 
-		return new UpdateMyProfileResponseDto("회원 정보가 수정되었습니다.");
+		return new UpdateMyProfileResponseDto("회원 정보가 수정되었습니다.", user);
+	}
+
+	// 비밀번호 변경 로직
+	@Transactional
+	public UpdatePasswordResponseDto userUpdatePassword(Integer userId, UpdatePasswordRequestDto updatePasswordRequest) {
+
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND));
+
+		// 비밀번호 검증 로직
+		if(!passwordEncoder.matches(updatePasswordRequest.getOldPassword(), user.getPassword())) {
+			throw new BadRequestException(ErrorCode.PASSWORD_MISMATCH);
+		}
+
+		// 새로운 비밀번호와 재입력 비밀번호 검증 로직
+		if(!updatePasswordRequest.getNewPassword().equals(updatePasswordRequest.getReEnterPassword())) {
+			throw new BadRequestException(ErrorCode.PASSWORD_RE_ENTER_PASSWORD_MISMATCH);
+		}
+
+		// 새로운 비밀번호 해싱처리
+		String bcryptPassword = passwordEncoder.encode(updatePasswordRequest.getNewPassword());
+
+		user.updatePassword(bcryptPassword);
+
+		return new UpdatePasswordResponseDto("비밀번호가 업데이트 되었습니다.", user);
 	}
 }

--- a/src/main/java/excluz/excluz/domain/user/service/UserService.java
+++ b/src/main/java/excluz/excluz/domain/user/service/UserService.java
@@ -14,6 +14,7 @@ import excluz.excluz.common.exception.error.ErrorCode;
 import excluz.excluz.domain.user.dto.request.UserLoginRequestDto;
 import excluz.excluz.domain.user.dto.request.UserSignupRequestDto;
 import excluz.excluz.domain.user.dto.request.UserWithdrawRequestDto;
+import excluz.excluz.domain.user.dto.response.MyProfileResponseDto;
 import excluz.excluz.domain.user.dto.response.UserLoginResponseDto;
 import excluz.excluz.domain.user.dto.response.UserProfileResponseDto;
 import excluz.excluz.domain.user.dto.response.UserSignupResponseDto;
@@ -120,4 +121,13 @@ public class UserService {
 		return new UserProfileResponseDto(user);
 	}
 
+	// 마이페이지
+	@Transactional(readOnly = true)
+	public MyProfileResponseDto getMyProfile(Integer userId) {
+
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND));
+
+		return new MyProfileResponseDto(user);
+	}
 }

--- a/src/main/java/excluz/excluz/domain/user/service/UserService.java
+++ b/src/main/java/excluz/excluz/domain/user/service/UserService.java
@@ -11,10 +11,12 @@ import excluz.excluz.common.entity.User;
 import excluz.excluz.common.exception.BadRequestException;
 import excluz.excluz.common.exception.NotFoundException;
 import excluz.excluz.common.exception.error.ErrorCode;
+import excluz.excluz.domain.user.dto.request.UpdateMyProfileRequestDto;
 import excluz.excluz.domain.user.dto.request.UserLoginRequestDto;
 import excluz.excluz.domain.user.dto.request.UserSignupRequestDto;
 import excluz.excluz.domain.user.dto.request.UserWithdrawRequestDto;
 import excluz.excluz.domain.user.dto.response.MyProfileResponseDto;
+import excluz.excluz.domain.user.dto.response.UpdateMyProfileResponseDto;
 import excluz.excluz.domain.user.dto.response.UserLoginResponseDto;
 import excluz.excluz.domain.user.dto.response.UserProfileResponseDto;
 import excluz.excluz.domain.user.dto.response.UserSignupResponseDto;
@@ -84,19 +86,19 @@ public class UserService {
 	// 회원탈퇴
 	@Transactional
 	public UserWithdrawResponseDto userWithdraw(
-		Integer userId, UserWithdrawRequestDto userWithdrawRequestDto) {
+		Integer userId, UserWithdrawRequestDto userWithdrawRequest) {
 
 		// 유저 정보를 userId 로 조회
 		User user = userRepository.findById(userId)
 			.orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND));
 
 		// 리퀘스트 요청에 들어온 비밀번호와 재확인 비밀번호가 일치 하지 않을 시 예외
-		if (!userWithdrawRequestDto.getPassword().equals(userWithdrawRequestDto.getReEnterPassword())) {
+		if (!userWithdrawRequest.getPassword().equals(userWithdrawRequest.getReEnterPassword())) {
 			throw new BadRequestException(ErrorCode.PASSWORD_MISMATCH);
 		}
 
 		// 비밀번호 검증 로직
-		if(!passwordEncoder.matches(userWithdrawRequestDto.getPassword(), user.getPassword())) {
+		if(!passwordEncoder.matches(userWithdrawRequest.getPassword(), user.getPassword())) {
 			throw new BadRequestException(ErrorCode.PASSWORD_MISMATCH);
 		}
 
@@ -108,7 +110,7 @@ public class UserService {
 
 	// 유저 조회
 	@Transactional(readOnly = true)
-	public UserProfileResponseDto getProfile(Integer userId) {
+	public UserProfileResponseDto userGetProfile(Integer userId) {
 
 		User user = userRepository.findById(userId)
 			.orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND));
@@ -123,11 +125,33 @@ public class UserService {
 
 	// 마이페이지
 	@Transactional(readOnly = true)
-	public MyProfileResponseDto getMyProfile(Integer userId) {
+	public MyProfileResponseDto userGetMyProfile(Integer userId) {
 
 		User user = userRepository.findById(userId)
 			.orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND));
 
 		return new MyProfileResponseDto(user);
+	}
+
+	// 내정보 수정
+	@Transactional
+	public UpdateMyProfileResponseDto userUpdateMyProfile(Integer userId, UpdateMyProfileRequestDto updateMyProfileRequest) {
+
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND));
+
+		// 비밀번호 검증로직
+		if(!passwordEncoder.matches(updateMyProfileRequest.getPassword(), user.getPassword())) {
+			throw new BadRequestException(ErrorCode.PASSWORD_MISMATCH);
+		}
+
+		user.updateUserProfile(
+			updateMyProfileRequest.getNickName(),
+			updateMyProfileRequest.getPhoneNumber(),
+			updateMyProfileRequest.getAddress(),
+			updateMyProfileRequest.getEmail()
+			);
+
+		return new UpdateMyProfileResponseDto("회원 정보가 수정되었습니다.");
 	}
 }


### PR DESCRIPTION
## 목적
- 회원 탈퇴를 위한 API 및 서비스 구현
- 회원 조회 및 마이페이지 조회 API 서비스 구현
- 회원 정보 수정 API, 서비스 구현
- 회원 비밀번호 변경 API, 서비스 구현

## 변경점
ErrorCode에 PASSWORD_RE_ENTER_PASSWORD_MISSMATCH 추가
기능들에 필요한 DTO추가
