### PR TITLE
:recycle: refactor: Refactor cart item creation and update logic for clarity

### DIFF
--- a/src/main/java/excluz/excluz/domain/cartItem/service/CartItemService.java
+++ b/src/main/java/excluz/excluz/domain/cartItem/service/CartItemService.java
@@ -1,7 +1,6 @@
 package excluz.excluz.domain.cartItem.service;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;

--- a/src/main/java/excluz/excluz/domain/cartItem/service/CartItemService.java
+++ b/src/main/java/excluz/excluz/domain/cartItem/service/CartItemService.java
@@ -95,15 +95,18 @@ public class CartItemService {
 		CartItem cartItem = cartItemRepository.findByIdAndUserId(cartItemId, userId)
 			.orElseThrow(() -> new NotFoundException(ErrorCode.CART_ITEM_NOT_FOUND));
 
-		// 장바구니에 담긴 상품의 정보 가져오기
+		// 장바구니에 담긴 해당 아이템의 정보 가져오기
 		Item item = cartItem.getItem();
 
-		// 재고 체크 (요청된 개수(기존 장바구니 개수 + 새로 요청한 개수)가 재고보다 많은 경우 예외 발생)
-		if (cartItem.getQuantity() + requestDto.getQuantity() > item.getRemainingQuantity()) {
+		// 사용자가 입력한 개수를 장바구니 속 해당 아이템의 최종 개수로 설정
+		Integer updatedQuantity = requestDto.getQuantity();
+
+		// 재고 체크 (요청된 개수가 재고보다 많은 경우 예외 발생)
+		if (updatedQuantity > item.getRemainingQuantity()) {
 			throw new BadRequestException(ErrorCode.OUT_OF_STOCK);
 		}
 
-		// 개수 업데이트
+		// 개수 업데이트 (기존 개수와 관계없이 사용자가 입력한 개수로 설정)
 		cartItem.updateQuantity(requestDto.getQuantity());
 
 		return GetCartItemResponseDto.builder()

--- a/src/main/java/excluz/excluz/domain/cartItem/service/CartItemService.java
+++ b/src/main/java/excluz/excluz/domain/cartItem/service/CartItemService.java
@@ -38,29 +38,21 @@ public class CartItemService {
 		Item item = itemRepository.findById(requestDto.getItemId())
 			.orElseThrow(() -> new NotFoundException(ErrorCode.ITEM_NOT_FOUND));
 
-		// 재고 체크 (요청된 개수가 재고보다 많은 경우 예외 발생)
-		if (requestDto.getQuantity() > item.getRemainingQuantity()) {
+		// 기존 장바구니에서 동일한 상품이 있는지 확인
+		CartItem cartItem = cartItemRepository.findByUserIdAndItemId(userId, requestDto.getItemId())
+			.orElseGet(() -> new CartItem(user, item, 0)); // 없으면 새 객체 생성 (초기 수량 0)
+
+		// 총 수량 계산
+		Integer newQuantity = cartItem.getQuantity() + requestDto.getQuantity();
+
+		// 재고 초과 여부 확인
+		if (newQuantity > item.getRemainingQuantity()) {
 			throw new BadRequestException(ErrorCode.OUT_OF_STOCK);
 		}
 
-		// 기존 장바구니에서 동일한 상품이 있는지 확인
-		Optional<CartItem> optionalCartItem = cartItemRepository.findByUserIdAndItemId(userId, requestDto.getItemId());
-
-		if (optionalCartItem.isPresent()) {
-			// 이미 장바구니에 있는 경우: 수량 증가
-			CartItem cartItem = optionalCartItem.get();
-			Integer newQuantity = cartItem.getQuantity() + requestDto.getQuantity();
-
-			if (newQuantity > item.getRemainingQuantity()) {
-				throw new BadRequestException(ErrorCode.OUT_OF_STOCK);
-			}
-
-			cartItem.updateQuantity(newQuantity);
-		} else {
-			// 장바구니에 없는 경우: 새로 추가
-			CartItem newCartItem = new CartItem(user, item, requestDto.getQuantity());
-			cartItemRepository.save(newCartItem);
-		}
+		// 수량 업데이트 및 저장
+		cartItem.updateQuantity(newQuantity);
+		cartItemRepository.save(cartItem);
 
 		return new CreateCartItemResponseDto();
 	}


### PR DESCRIPTION
##  목적
- 피드백을 반영하여 물품 생성(create) 코드의 가독성을 개선
- 물품 추가(update) 기능 개선

## 변경점
- `orElseGet`을 사용하여 장바구니 아이템이 없는 경우를 더 간결하게 처리
- 수량 검증 로직과 업데이트 로직을 분리하여 명확성을 높임
- 장바구니 아이템 개수 업데이트 시 기존 개수에 더하는 방식이 아니라, **사용자가 입력한 개수 그대로 반영되도록 수정**
- `CartItemService` 내 불필요한 import 문 제거하여 코드 정리