### PR TITLE
✅test: Make Uni Test Code for All Event and EventApplicant methods

### DIFF
--- a/src/main/java/excluz/excluz/common/entity/Event.java
+++ b/src/main/java/excluz/excluz/common/entity/Event.java
@@ -84,6 +84,10 @@ public class Event extends BaseEntity  {
         this.endDatetime = endDatetime;
     }
 
+    public void updateIsDeleted(Boolean isDeleted) {
+            this.isDeleted = isDeleted;
+    }
+
     public void completeEvent() {
         this.isCompleted = true;
     }

--- a/src/main/java/excluz/excluz/common/entity/EventApplicant.java
+++ b/src/main/java/excluz/excluz/common/entity/EventApplicant.java
@@ -11,7 +11,8 @@ import java.time.LocalDateTime;
 
 @Getter
 @Entity
-@Table(name = "event_applicants")
+@Table(name = "event_applicants",
+        uniqueConstraints = { @UniqueConstraint(columnNames = {"event_id", "email"}) } )
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class EventApplicant extends BaseEntity  {
 
@@ -23,7 +24,7 @@ public class EventApplicant extends BaseEntity  {
     @JoinColumn(name = "event_id", nullable = false)
     private Event event;
 
-    @Column(name = "email", length = 50, unique = true, nullable = false)
+    @Column(name = "email", length = 50, nullable = false)
     private String email;
 
     @Column(name = "applicant_name", length = 10, nullable = false)

--- a/src/main/java/excluz/excluz/domain/event/event/dto/EventRequestDto.java
+++ b/src/main/java/excluz/excluz/domain/event/event/dto/EventRequestDto.java
@@ -37,6 +37,15 @@ public class EventRequestDto {
     @Valid
     private List<EventItemRequestDto> eventItemList;
 
+    @AssertTrue(message = "이벤트 시작일시는 종료일시 이전이어야 합니다.")
+    public boolean isValidDateRange() {
+        // NotNull 검증은 위의 어노테이션이 처리하므로 null일 경우 검증 통과하도록 처리
+        if (startDatetime == null || endDatetime == null) {
+            return true;
+        }
+        return startDatetime.isBefore(endDatetime);
+    }
+
     @Builder
     public EventRequestDto(Integer storeId,
                            Integer numberOfWinners,

--- a/src/main/java/excluz/excluz/domain/event/event/dto/EventResponseDto.java
+++ b/src/main/java/excluz/excluz/domain/event/event/dto/EventResponseDto.java
@@ -25,7 +25,7 @@ public class EventResponseDto {
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
     private String generatedCode;
-    private List<EventItemDto> eventItems;
+    private List<EventItemDto> eventItemList;
 
     @Builder
     public EventResponseDto(Integer id,
@@ -39,7 +39,7 @@ public class EventResponseDto {
                             LocalDateTime createdAt,
                             LocalDateTime updatedAt,
                             String generatedCode,
-                            List<EventItemDto> eventItems) {
+                            List<EventItemDto> eventItemList) {
         this.id = id;
         this.streamerStoreId = streamerStoreId;
         this.numberOfWinners = numberOfWinners;
@@ -51,14 +51,14 @@ public class EventResponseDto {
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
         this.generatedCode = generatedCode;
-        this.eventItems = eventItems;
+        this.eventItemList = eventItemList;
     }
 
     // Event 엔티티와 EventItem 리스트를 받아서 EventResponseDto로 변환하는 정적 메서드
-    public static EventResponseDto fromWithItems(Event event, List<EventItem> eventItems) {
-        List<EventItemDto> eventItemDtos = null;
-        if (eventItems != null) {
-            eventItemDtos = eventItems.stream()
+    public static EventResponseDto fromWithItems(Event event, List<EventItem> eventItemList) {
+        List<EventItemDto> eventItemDtoList = null;
+        if (eventItemList != null) {
+            eventItemDtoList = eventItemList.stream()
                     .map(item -> EventItemDto.builder()
                             .id(item.getId())
                             .quantity(item.getQuantity())
@@ -79,7 +79,7 @@ public class EventResponseDto {
                 .createdAt(event.getCreatedAt())
                 .updatedAt(event.getUpdatedAt())
                 .generatedCode(event.getGeneratedCode())
-                .eventItems(eventItemDtos)
+                .eventItemList(eventItemDtoList)
                 .build();
     }
 
@@ -97,7 +97,7 @@ public class EventResponseDto {
                 .createdAt(event.getCreatedAt())
                 .updatedAt(event.getUpdatedAt())
                 .generatedCode(event.getGeneratedCode())
-                .eventItems(null) // EventItems를 포함하지 않음
+                .eventItemList(null) // EventItems를 포함하지 않음
                 .build();
     }
 }

--- a/src/main/java/excluz/excluz/domain/event/event/service/EventService.java
+++ b/src/main/java/excluz/excluz/domain/event/event/service/EventService.java
@@ -66,8 +66,8 @@ public class EventService {
 
             Integer requestedItemQuantity = eventItemRequestDto.getQuantity();
             item.removeRemainingQuantity(requestedItemQuantity * eventRequestDto.getNumberOfWinners());
-            EventItem eventItem = new EventItem(savedEvent, item, requestedItemQuantity);
 
+            EventItem eventItem = new EventItem(savedEvent, item, requestedItemQuantity);
             eventItemList.add(eventItem);
         }
 
@@ -98,10 +98,39 @@ public class EventService {
         return EventResponseDto.fromWithItems(event, eventItems);
     }
 
+    // 이벤트 취소 시 재고 복구 및 이벤트 상태 변경 (예: 이벤트 취소 플래그 추가 등으로 확장 가능)
+    @Transactional
+    public void cancelEvent(Integer eventId) {
+        Event event = eventRepository.findById(eventId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 이벤트를 찾을 수 없습니다. ID: " + eventId));
+
+        if (event.getIsCompleted()) {
+            throw new IllegalStateException("이미 마감된 이벤트는 취소할 수 없습니다.");
+        }
+
+        if (event.getIsDeleted()) {
+            return;
+        }
+
+        // 이벤트의 종료 여부를 endDatetime과 현재 시간으로 재확인 (종료, 취소시에도 재고 복구)
+        List<EventItem> eventItems = eventItemRepository.findByEvent(event);
+        for (EventItem eventItem : eventItems) {
+            Item item = eventItem.getItem();
+            item.addRemainingQuantity(eventItem.getQuantity() * event.getNumberOfWinners());
+        }
+
+        event.updateIsDeleted(true);
+        eventRepository.save(event);
+    }
+
     // 이벤트 마감 메서드 추가
     public EventClosingResponseDto closeEvent(Integer eventId) {
         Event event = eventRepository.findById(eventId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 이벤트를 찾을 수 없습니다. ID: " + eventId));
+
+        if (event.getIsDeleted()) {
+            throw new IllegalStateException("취소된 이벤트입니다.");
+        }
 
         if (event.getIsCompleted()) {
             throw new IllegalStateException("이미 마감된 이벤트입니다.");
@@ -109,7 +138,6 @@ public class EventService {
 
         // 이벤트 응모자 조회
         List<EventApplicant> applicantList = eventApplicantRepository.findByEvent(event);
-
         if (applicantList.isEmpty()) {
             throw new IllegalStateException("해당 이벤트에 응모자가 없습니다.");
         }
@@ -129,28 +157,23 @@ public class EventService {
                 }
             }
         } else if (event.getSelectionMethod() == SelectionMethod.FIRST_COME_FIRST_SERVED) {
-            
+//      응모시에 이미 WINNER/LOSER 구분 완료
         } else {
             throw new UnsupportedOperationException("지원되지 않는 선정 방식입니다.");
         }
 
         event.completeEvent();
 
-        // 변경사항 저장
         eventRepository.save(event);
         eventApplicantRepository.saveAll(applicantList);
 
-        // EventItems 조회
         List<EventItem> eventItems = eventItemRepository.findByEvent(event);
 
-        // 응답 DTO 생성
-        EventClosingResponseDto eventClosingResponseDto = EventClosingResponseDto.from(event, eventItems, applicantList);
-
-        return eventClosingResponseDto;
+        return EventClosingResponseDto.from(event, eventItems, applicantList);
     }
 
     private String generateUniqueCode() {
-        // 고유 코드 생성 로직 구현
+        // todo: 고유 코드 생성 로직 구현 (예제용 코드)
         return "UNIQUE_CODE" + eventRepository.count();
     }
 

--- a/src/main/java/excluz/excluz/domain/event/eventApplicant/repository/EventApplicantRepository.java
+++ b/src/main/java/excluz/excluz/domain/event/eventApplicant/repository/EventApplicantRepository.java
@@ -10,6 +10,10 @@ import java.util.Optional;
 
 public interface EventApplicantRepository extends JpaRepository<EventApplicant, Integer> {
     Optional<EventApplicant> findByEventAndEmailAndApplicantPassword(Event event, String email, String applicantPassword);
+
     List<EventApplicant> findByEvent(Event event);
+
     int countByEventAndApplicantStatus(Event event, ApplicantStatus status);
+
+    Boolean existsByEventAndEmail(Event event, String email);
 }

--- a/src/main/java/excluz/excluz/domain/event/eventApplicant/service/EventApplicantService.java
+++ b/src/main/java/excluz/excluz/domain/event/eventApplicant/service/EventApplicantService.java
@@ -13,6 +13,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
+
 @Service
 @Slf4j
 @RequiredArgsConstructor
@@ -25,8 +27,24 @@ public class EventApplicantService {
         Event event = eventRepository.findByGeneratedCode(code)
                 .orElseThrow(() -> new IllegalArgumentException("잘못된 이벤트 코드입니다."));
 
-        if (event.getIsCompleted()){
-            throw new IllegalArgumentException("이미 마감 된 이벤트입니다.");
+        if (event.getIsCompleted()) {
+            throw new IllegalArgumentException("이미 마감된 이벤트입니다.");
+        }
+        if (event.getIsDeleted()) {
+            throw new IllegalArgumentException("취소된 이벤트입니다..");
+        }
+
+//        이벤트 시간 관련 로직
+        LocalDateTime now = LocalDateTime.now();
+        if (now.isBefore(event.getStartDatetime())) {
+            throw new IllegalStateException("아직 이벤트가 시작되지 않았습니다.");
+        }
+        if (now.isAfter(event.getEndDatetime())) {
+            throw new IllegalStateException("이벤트가 이미 종료되었습니다.");
+        }
+
+        if (eventApplicantRepository.existsByEventAndEmail(event, requestDto.getEmail())) {
+            throw new IllegalArgumentException("이미 해당 이벤트에 응모한 이메일입니다.");
         }
 
         EventApplicant eventApplicant = EventApplicant.builder()
@@ -49,7 +67,6 @@ public class EventApplicantService {
         }
 
         EventApplicant savedApplicant = eventApplicantRepository.save(eventApplicant);
-
         return EventApplicantResponseDto.from(savedApplicant);
     }
 
@@ -72,18 +89,14 @@ public class EventApplicantService {
         }
 
         if (requestDto.getApplicantName() != null) {
-          
             eventApplicant.updateApplicantName(requestDto.getApplicantName());
-
         }
         if (requestDto.getDeliveryAddress() != null) {
             eventApplicant.updateDeliveryAddress(requestDto.getDeliveryAddress());
         }
 
         eventApplicant.updateApplicantStatus(ApplicantStatus.CONFIRMED);
-
         EventApplicant updatedApplicant = eventApplicantRepository.save(eventApplicant);
-
         return EventApplicantResponseDto.from(updatedApplicant);
     }
 }

--- a/src/test/java/excluz/excluz/EventServiceDBTest.java
+++ b/src/test/java/excluz/excluz/EventServiceDBTest.java
@@ -1,7 +1,7 @@
 // package excluz.excluz;
-
-
-
+//
+//
+//
 // import excluz.excluz.common.entity.*;
 // import excluz.excluz.domain.event.event.dto.EventClosingResponseDto;
 // import excluz.excluz.domain.event.event.dto.EventRequestDto;
@@ -21,54 +21,54 @@
 // import excluz.excluz.domain.streamer.repository.StreamerRepository;
 // import org.junit.jupiter.api.Test;
 // import org.junit.jupiter.api.BeforeEach;
-
+//
 // import org.springframework.beans.factory.annotation.Autowired;
 // import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 // import org.springframework.boot.test.context.SpringBootTest;
-
+//
 // import java.time.LocalDateTime;
 // import java.util.*;
-
+//
 // import static org.junit.jupiter.api.Assertions.*;
-
+//
 // @SpringBootTest
 // @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 // public class EventServiceDBTest {
-
-
+//
+//
 //     @Autowired
 //     private StreamerRepository streamerRepository;
-
+//
 //     @Autowired
 //     private EventService eventService;
-
+//
 //     @Autowired
 //     private EventApplicantService eventApplicantService;
-
+//
 //     @Autowired
 //     private StoreRepository storeRepository;
-
+//
 //     @Autowired
 //     private EventRepository eventRepository;
-
+//
 //     @Autowired
 //     private EventItemRepository eventItemRepository;
-
+//
 //     @Autowired
 //     private ItemRepository itemRepository;
-
+//
 //     @Autowired
 //     private EventApplicantRepository eventApplicantRepository;
-
+//
 //     private Store testStore;
 //     private Item testItem1;
 //     private Item testItem2;
-
+//
 //     @BeforeEach
 //     public void setup() {
 //         // 고유한 접미사 생성
-//         String uniqueSuffix = UUID.randomUUID().toString().substring(0, 2);
-
+//         String uniqueSuffix = UUID.randomUUID().toString().substring(0, 4);
+//
 //         Streamer streamer = Streamer.builder()
 //                 .name("스트리머" + uniqueSuffix)
 //                 .nickName("스트리머" + uniqueSuffix)
@@ -77,7 +77,7 @@
 //                 .password("password")
 //                 .build();
 //          streamerRepository.save(streamer);
-
+//
 //         Store store = Store.builder()
 //                 .streamer(streamer)
 //                 .storeName("StoreName" + uniqueSuffix)
@@ -85,7 +85,7 @@
 //                 .registrationNumber("RegNum" + uniqueSuffix)
 //                 .build();
 //         testStore = storeRepository.save(store);
-
+//
 //         Item item1 = Item.builder()
 //                 .store(testStore) // Item은 Store를 참조합니다.
 //                 .itemName("TestItem" + uniqueSuffix + 1)
@@ -94,7 +94,7 @@
 //                 .remainingQuantity(100)
 //                 .build();
 //         testItem1 = itemRepository.save(item1);
-
+//
 //         Item item2 = Item.builder()
 //                 .store(testStore) // Item은 Store를 참조합니다.
 //                 .itemName("TestItem" + uniqueSuffix + 2)
@@ -103,19 +103,23 @@
 //                 .remainingQuantity(100)
 //                 .build();
 //         testItem2 = itemRepository.save(item2);
-
+//
 //     }
-
+//
 //     @Test
 //     public void testCreateEvent() {
 //         // Arrange
 //         String uniqueSuffix = UUID.randomUUID().toString().substring(0, 8);
-
+//
 //         // EventItemRequestDto 준비
-//         List<EventItemRequestDto> eventItems = new ArrayList<>();
-//         EventItemRequestDto eventItemRequestDto = new EventItemRequestDto(testItem1.getId(), 10);
-//         eventItems.add(eventItemRequestDto);
-
+//         List<EventItemRequestDto> eventItemList = new ArrayList<>();
+//
+//         EventItemRequestDto eventItemRequestDto1 = new EventItemRequestDto(testItem1.getId(), 10);
+//         eventItemList.add(eventItemRequestDto1);
+//
+//         EventItemRequestDto eventItemRequestDto2 = new EventItemRequestDto(testItem2.getId(), 3);
+//         eventItemList.add(eventItemRequestDto2);
+//
 //         // EventRequestDto 준비
 //         EventRequestDto eventRequestDto = EventRequestDto.builder()
 //                 .storeId(testStore.getId())
@@ -124,12 +128,12 @@
 //                 .selectionMethod("RANDOM_DRAW")
 //                 .startDatetime(LocalDateTime.now())
 //                 .endDatetime(LocalDateTime.now().plusDays(1))
-//                 .eventItems(eventItems)
+//                 .eventItemList(eventItemList)
 //                 .build();
-
+//
 //         // Act
 //         EventResponseDto eventResponseDto = eventService.createEvent(eventRequestDto);
-
+//
 //         // Assert
 //         assertNotNull(eventResponseDto);
 //         assertNotNull(eventResponseDto.getId());
@@ -139,63 +143,63 @@
 //         assertEquals("ALL_USERS", eventResponseDto.getParticipantCondition());
 //         assertEquals("RANDOM_DRAW", eventResponseDto.getSelectionMethod());
 //         assertNotNull(eventResponseDto.getGeneratedCode());
-//         assertNotNull(eventResponseDto.getEventItems());
-//         assertEquals(1, eventResponseDto.getEventItems().size());
-
+//         assertNotNull(eventResponseDto.getEventItemList());
+//         assertEquals(2, eventResponseDto.getEventItems().size());
+//
 //         // 데이터베이스에 데이터가 저장되었는지 확인
 //         Optional<Event> eventOptional = eventRepository.findById(eventResponseDto.getId());
 //         assertTrue(eventOptional.isPresent());
 //         Event event = eventOptional.get();
 //         assertEquals(event.getStore().getId(), testStore.getId());
-
-//         List<EventItem> eventItemList = eventItemRepository.findByEvent(event);
-//         assertEquals(1, eventItemList.size());
-//         EventItem eventItem = eventItemList.get(0);
+//
+//         List<EventItem> eventItemList2 = eventItemRepository.findByEvent(event);
+//         assertEquals(2, eventItemList.size());
+//         EventItem eventItem = eventItemList2.get(0);
 //         assertEquals(eventItem.getItem().getId(), testItem1.getId());
 //         assertEquals(eventItem.getQuantity(), 10);
 //     }
-
+//
 //     @Test
 //     public void testGetAllEvents() {
 //         // Arrange
 //         // 이벤트 여러 개 생성
 //         createTestEvent();
 //         createTestEvent();
-
+//
 //         // Act
 //         List<EventResponseDto> eventList = eventService.getAllEvents();
-
+//
 //         // Assert
 //         assertNotNull(eventList);
 //         assertTrue(eventList.size() >=2); // 다른 테스트로 인해 이벤트가 더 있을 수 있음
-
+//
 //     }
-
+//
 //     @Test
 //     public void testGetEvent() {
 //         // Arrange
 //         EventResponseDto eventResponseDto = createTestEvent();
-
+//
 //         // Act
 //         EventResponseDto fetchedEvent = eventService.getEvent(eventResponseDto.getId());
-
+//
 //         // Assert
 //         assertNotNull(fetchedEvent);
 //         assertEquals(eventResponseDto.getId(), fetchedEvent.getId());
 //         assertEquals(eventResponseDto.getStreamerStoreId(), fetchedEvent.getStreamerStoreId());
 //         assertEquals(eventResponseDto.getNumberOfWinners(), fetchedEvent.getNumberOfWinners());
-
+//
 //         assertNotNull(fetchedEvent.getEventItems(), "이벤트 아이템 목록이 null이면 안 됩니다.");
 // // createTestEvent()에서 아이템이 하나 이상 들어가는 경우가 있다면, 개수도 검사
 //         assertFalse(fetchedEvent.getEventItems().isEmpty(), "이벤트 아이템 목록이 비어 있으면 안 됩니다.");
-
+//
 // // 콘솔 출력으로 확인
 //         System.out.println("========== [단건 조회 결과] ==========");
 //         System.out.println("Event ID : " + fetchedEvent.getId());
 //         System.out.println("Store ID : " + fetchedEvent.getStreamerStoreId());
 //         System.out.println("Number of Winners : " + fetchedEvent.getNumberOfWinners());
 //         System.out.println("Event Items : " + fetchedEvent.getEventItems().size());
-
+//
 // // 각 아이템 정보도 출력해보기
 //         for (EventItemDto itemDto : fetchedEvent.getEventItems()) {
 //             System.out.println("Item ID           : " + itemDto.getId());
@@ -203,18 +207,18 @@
 //             // 필요한 다른 필드도 있으면 추가 출력
 //         }
 //     }
-
+//
 //     @Test
 //     public void testCloseEvent() {
 //         // Arrange
 //         EventResponseDto eventResponseDto = createTestEvent();
-
+//
 //         // 응모자 생성
 //         Event event = eventRepository.findById(eventResponseDto.getId()).get();
-
+//
 //         for(int i=0;i<10;i++){
 //             String uniqueSuffix = UUID.randomUUID().toString().substring(0, 3);
-
+//
 //             EventApplicant applicant = EventApplicant.builder()
 //                     .event(event)
 //                     .email("applicant" + uniqueSuffix + "@example.com")
@@ -225,17 +229,17 @@
 //                     .build();
 //             eventApplicantRepository.save(applicant);
 //         }
-
+//
 //         // Act
 //         EventClosingResponseDto closingResponse = eventService.closeEvent(eventResponseDto.getId());
-
+//
 //         // Assert
 //         assertNotNull(closingResponse);
 //         assertEquals(eventResponseDto.getId(), closingResponse.getId());
 //         assertTrue(closingResponse.getIsCompleted());
 //         assertNotNull(closingResponse.getEventApplicants());
 //         assertEquals(10, closingResponse.getEventApplicants().size());
-
+//
 //         // 응모자 상태가 WINNER 또는 LOSER로 업데이트되었는지 확인
 //         List<EventApplicant> applicants = eventApplicantRepository.findByEvent(event);
 //         int winnerCount = 0;
@@ -248,14 +252,14 @@
 //         }
 //         assertEquals(eventResponseDto.getNumberOfWinners(), winnerCount);
 //     }
-
+//
 //     @Test
 //     public void testConfirmReceipt() {
 //         EventResponseDto eventDto = createTestEvent();
-
+//
 //         Event event = eventRepository.findById(eventDto.getId())
 //                 .orElseThrow(() -> new IllegalStateException("이벤트 생성에 실패했습니다."));
-
+//
 //         // 2) 응모자(EventApplicant) 하나 생성 (처음부터 WINNER로 세팅)
 //         String uniqueSuffix = UUID.randomUUID().toString().substring(0, 3);
 //         EventApplicant applicant = EventApplicant.builder()
@@ -267,17 +271,17 @@
 //                 .applicantStatus(ApplicantStatus.WINNER)  // ← 여기서 WINNER 상태로 생성
 //                 .build();
 //         EventApplicant savedApplicant = eventApplicantRepository.save(applicant);
-
+//
 // // 3) “수령 확정” 요청 DTO
 //         EventApplicantRequestDto updateRequest = EventApplicantRequestDto.builder()
 //                 .applicantName("변경된이름")
 //                 .deliveryAddress("변경된주소")
 //                 .build();
-
+//
 // // 4) 실제 “수령 확정” 메서드 호출
 //         EventApplicantResponseDto updatedResponse =
 //                 eventApplicantService.confirmReceipt(savedApplicant.getId(), updateRequest);
-
+//
 // // 5) 검증
 //         assertNotNull(updatedResponse);
 //         assertEquals(savedApplicant.getId(), updatedResponse.getId());
@@ -285,20 +289,22 @@
 //         assertEquals("변경된주소", updatedResponse.getDeliveryAddress());
 //         assertEquals(ApplicantStatus.CONFIRMED, updatedResponse.getApplicantStatus());
 //     }
-
-
+//
+//
 //     // 테스트 이벤트를 생성하는 헬퍼 메서드
 //     private EventResponseDto createTestEvent() {
 //         String uniqueSuffix = UUID.randomUUID().toString().substring(0, 3);
-
+//
 //         // EventItemRequestDto 준비
-//         List<EventItemRequestDto> eventItems = new ArrayList<>();
+//         List<EventItemRequestDto> eventItemList = new ArrayList<>();
+//
 //         EventItemRequestDto eventItemRequestDto1 = new EventItemRequestDto(testItem1.getId(), 10);
-//         eventItems.add(eventItemRequestDto1);
+//         eventItemList.add(eventItemRequestDto1);
+//
 //         EventItemRequestDto eventItemRequestDto2 = new EventItemRequestDto(testItem2.getId(), 3);
-//         eventItems.add(eventItemRequestDto2);
-
-
+//         eventItemList.add(eventItemRequestDto2);
+//
+//
 //         // EventRequestDto 준비
 //         EventRequestDto eventRequestDto = EventRequestDto.builder()
 //                 .storeId(testStore.getId())
@@ -307,11 +313,11 @@
 //                 .selectionMethod("RANDOM_DRAW")
 //                 .startDatetime(LocalDateTime.now())
 //                 .endDatetime(LocalDateTime.now().plusDays(1))
-//                 .eventItems(eventItems)
+//                 .eventItemList(eventItemList)
 //                 .build();
-
+//
 //         return eventService.createEvent(eventRequestDto);
 //     }
-
-
+//
+//
 // }

--- a/src/test/java/excluz/excluz/EventServiceUnitTest.java
+++ b/src/test/java/excluz/excluz/EventServiceUnitTest.java
@@ -1,0 +1,450 @@
+package excluz.excluz;
+
+import excluz.excluz.common.entity.*;
+import excluz.excluz.domain.event.event.dto.EventClosingResponseDto;
+import excluz.excluz.domain.event.event.dto.EventRequestDto;
+import excluz.excluz.domain.event.event.dto.EventResponseDto;
+import excluz.excluz.domain.event.event.enums.ParticipantCondition;
+import excluz.excluz.domain.event.event.enums.SelectionMethod;
+import excluz.excluz.domain.event.event.repository.EventRepository;
+import excluz.excluz.domain.event.event.service.EventService;
+import excluz.excluz.domain.event.eventApplicant.dto.EventApplicantRequestDto;
+import excluz.excluz.domain.event.eventApplicant.dto.EventApplicantResponseDto;
+import excluz.excluz.domain.event.eventApplicant.enums.ApplicantStatus;
+import excluz.excluz.domain.event.eventApplicant.repository.EventApplicantRepository;
+import excluz.excluz.domain.event.eventApplicant.service.EventApplicantService;
+import excluz.excluz.domain.event.eventItem.dto.EventItemRequestDto;
+import excluz.excluz.domain.event.eventItem.repository.EventItemRepository;
+import excluz.excluz.domain.store.item.repository.ItemRepository;
+import excluz.excluz.domain.store.store.repository.StoreRepository;
+import excluz.excluz.domain.streamer.repository.StreamerRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public class EventServiceUnitTest {
+    @Autowired
+    private StreamerRepository streamerRepository;
+
+    @Autowired
+    private StoreRepository storeRepository;
+
+    @Autowired
+    private ItemRepository itemRepository;
+
+    @Autowired
+    private EventRepository eventRepository;
+
+    @Autowired
+    private EventItemRepository eventItemRepository;
+
+    @Autowired
+    private EventApplicantRepository eventApplicantRepository;
+
+    @Autowired
+    private EventService eventService;
+
+    @Autowired
+    private EventApplicantService eventApplicantService;
+
+    private Store testStore;
+    private Item testItem1;
+    private Item testItem2;
+    private String uniqueSuffix;
+
+    @BeforeEach
+    public void setup() {
+        // 각 테스트마다 중복데이터 방지를 위해 고유 접미사 사용
+        uniqueSuffix = UUID.randomUUID().toString().substring(0, 4);
+
+        Streamer streamer = Streamer.builder()
+                .name("스트리머" + uniqueSuffix)
+                .nickName("스트리머" + uniqueSuffix)
+                .phoneNumber("010" + ((int) (Math.random() * 90000000 + 10000000)))
+                .email("streamer" + uniqueSuffix + "@example.com")
+                .password("password")
+                .build();
+        streamerRepository.save(streamer);
+
+        Store store = Store.builder()
+                .streamer(streamer)
+                .storeName("StoreName" + uniqueSuffix)
+                .address("StoreAddress" + uniqueSuffix)
+                .registrationNumber("RegNum" + uniqueSuffix)
+                .build();
+        testStore = storeRepository.save(store);
+
+        Item item1 = Item.builder()
+                .store(testStore)
+                .itemName("TestItem" + uniqueSuffix + "1")
+                .explanation("Description")
+                .price(5000)
+                .remainingQuantity(100)
+                .build();
+        testItem1 = itemRepository.save(item1);
+
+        Item item2 = Item.builder()
+                .store(testStore)
+                .itemName("TestItem" + uniqueSuffix + "2")
+                .explanation("Description")
+                .price(10000)
+                .remainingQuantity(100)
+                .build();
+        testItem2 = itemRepository.save(item2);
+    }
+
+    // --------------------1. createEvent 테스트--------------------
+    @Test
+    public void testCreateEventSuccess() {
+        List<EventItemRequestDto> eventItemList = new ArrayList<>();
+        eventItemList.add(new EventItemRequestDto(testItem1.getId(), 5));
+        eventItemList.add(new EventItemRequestDto(testItem2.getId(), 2));
+
+        EventRequestDto requestDto = EventRequestDto.builder()
+                .storeId(testStore.getId())
+                .numberOfWinners(3)
+                .participantCondition(ParticipantCondition.ALL_USERS.name())
+                .selectionMethod(SelectionMethod.RANDOM_DRAW.name())
+                .startDatetime(LocalDateTime.now().minusMinutes(1))
+                .endDatetime(LocalDateTime.now().plusDays(1))
+                .eventItemList(eventItemList)
+                .build();
+
+        EventResponseDto responseDto = eventService.createEvent(requestDto);
+
+        assertNotNull(responseDto);
+        assertNotNull(responseDto.getId());
+        assertEquals(testStore.getId(), responseDto.getStreamerStoreId());
+        assertEquals(3, responseDto.getNumberOfWinners());
+        assertFalse(responseDto.getIsCompleted());
+        assertEquals(ParticipantCondition.ALL_USERS.name(), responseDto.getParticipantCondition());
+        assertEquals(SelectionMethod.RANDOM_DRAW.name(), responseDto.getSelectionMethod());
+        assertNotNull(responseDto.getGeneratedCode());
+        assertNotNull(responseDto.getEventItemList());
+        assertEquals(2, responseDto.getEventItemList().size());
+
+        // DB 저장 여부 확인
+        Optional<Event> eventOptional = eventRepository.findById(responseDto.getId());
+        assertTrue(eventOptional.isPresent());
+        Event event = eventOptional.get();
+        List<EventItem> eventItems = eventItemRepository.findByEvent(event);
+        assertEquals(2, eventItems.size());
+        // 아이템 수량 및 연관 Item 체크
+        EventItem eventItem = eventItems.get(0);
+        assertTrue(eventItem.getItem().getId().equals(testItem1.getId()) || eventItem.getItem().getId().equals(testItem2.getId()));
+    }
+
+    // 1-2. 잘못된 ID로 create
+    @Test
+    public void testCreateEventFailure_InvalidStore() {
+        List<EventItemRequestDto> eventItemList = new ArrayList<>();
+        eventItemList.add(new EventItemRequestDto(testItem1.getId(), 5));
+
+        EventRequestDto requestDto = EventRequestDto.builder()
+                .storeId(-999)   // 잘못된 스토어 ID
+                .numberOfWinners(3)
+                .participantCondition(ParticipantCondition.ALL_USERS.name())
+                .selectionMethod(SelectionMethod.RANDOM_DRAW.name())
+                .startDatetime(LocalDateTime.now().minusMinutes(1))
+                .endDatetime(LocalDateTime.now().plusDays(1))
+                .eventItemList(eventItemList)
+                .build();
+
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            eventService.createEvent(requestDto);
+        });
+        assertTrue(exception.getMessage().contains("해당 스토어를 찾을 수 없습니다."));
+    }
+
+
+    // 1-3. 잘못된 ID로 create
+    @Test
+    public void testCreateEventFailure_ItemNotBelongToStore() {
+        String uniqueSuffix = UUID.randomUUID().toString().substring(0, 4);
+        Streamer streamer2 = Streamer.builder()
+                .name("스트리머" + uniqueSuffix)
+                .nickName("스트리머" + uniqueSuffix)
+                .phoneNumber("010" + ((int) (Math.random() * 90000000 + 10000000)))
+                .email("streamer2" + uniqueSuffix + "@example.com")
+                .password("password")
+                .build();
+        streamerRepository.save(streamer2);
+
+        Store otherStore = Store.builder()
+                .streamer(streamer2)
+                .storeName("OtherStore" + uniqueSuffix)
+                .address("OtherAddress" + uniqueSuffix)
+                .registrationNumber("OtherReg" + uniqueSuffix)
+                .build();
+        otherStore = storeRepository.save(otherStore);
+
+        Item otherItem = Item.builder()
+                .store(otherStore)
+                .itemName("OtherItem" + uniqueSuffix)
+                .explanation("Other Desc")
+                .price(7000)
+                .remainingQuantity(50)
+                .build();
+        otherItem = itemRepository.save(otherItem);
+
+        List<EventItemRequestDto> eventItemList = new ArrayList<>();
+        // 기존 스토어에 속하지 않는 아이템 사용
+        eventItemList.add(new EventItemRequestDto(otherItem.getId(), 2));
+
+        EventRequestDto requestDto = EventRequestDto.builder()
+                .storeId(testStore.getId())  // 기본 store
+                .numberOfWinners(3)
+                .participantCondition(ParticipantCondition.ALL_USERS.name())
+                .selectionMethod(SelectionMethod.RANDOM_DRAW.name())
+                .startDatetime(LocalDateTime.now().minusMinutes(1))
+                .endDatetime(LocalDateTime.now().plusDays(1))
+                .eventItemList(eventItemList)
+                .build();
+
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            eventService.createEvent(requestDto);
+        });
+        assertTrue(exception.getMessage().contains("현재 스토어에 소속되어 있지 않습니다."));
+    }
+
+    // -------------------- 2. getAllEvents, getEvent 테스트 --------------------
+    @Test
+    public void testGetAllEventsSuccess() {
+        createTestEvent();
+        createTestEvent();
+
+        List<EventResponseDto> eventList = eventService.getAllEvents();
+
+        assertNotNull(eventList);
+        assertTrue(eventList.size() >= 2);
+        for (EventResponseDto eventResponseDto : eventList) {
+            System.out.println("Event Id: " + eventResponseDto.getId());
+            System.out.println("Streamer Id: " + eventResponseDto.getStreamerStoreId());
+            System.out.println("ItemList: " + eventResponseDto.getEventItemList()); // 여러 건 조회에서는 Item들은 null 반환
+            System.out.println();
+        }
+    }
+
+//   2-2. 단건 조회
+    @Test
+    public void testGetEventSuccess() {
+        EventResponseDto createdEvent = createTestEvent();
+
+        EventResponseDto fetchedEvent = eventService.getEvent(createdEvent.getId());
+
+        assertNotNull(fetchedEvent);
+        assertEquals(createdEvent.getId(), fetchedEvent.getId());
+        assertNotNull(fetchedEvent.getEventItemList());
+        assertFalse(fetchedEvent.getEventItemList().isEmpty());
+        // 콘솔 출력 (디버깅용)
+        System.out.println("Event ID : " + fetchedEvent.getId());
+    }
+
+//  2-3. 존재하지 않는 조회
+    @Test
+    public void testGetEventFailure_NotFound() {
+        // Act & Assert
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            eventService.getEvent(-999);
+        });
+        assertTrue(exception.getMessage().contains("해당 이벤트를 찾을 수 없습니다."));
+    }
+
+    // -------------------- 3. closeEvent 테스트 --------------------
+    @Test
+    public void testCloseEventSuccess() {
+        EventResponseDto createdEvent = createTestEvent();
+        Event event = eventRepository.findById(createdEvent.getId()).orElseThrow();
+
+        int totalApplicants = 10;
+        for (int i = 0; i < totalApplicants; i++) {
+            String uniqueSuffix = UUID.randomUUID().toString().substring(0, 3);
+            EventApplicant applicant = EventApplicant.builder()
+                    .event(event)
+                    .email("applicant" + uniqueSuffix + "@example.com")
+                    .applicantName("지원자" + uniqueSuffix)
+                    .applicantPassword("password")
+                    .deliveryAddress("Address" + uniqueSuffix)
+                    .applicantStatus(ApplicantStatus.WAITING)
+                    .build();
+            eventApplicantRepository.save(applicant);
+        }
+
+        EventClosingResponseDto closingResponse = eventService.closeEvent(createdEvent.getId());
+
+        assertNotNull(closingResponse);
+        assertEquals(createdEvent.getId(), closingResponse.getId());
+        assertTrue(closingResponse.getIsCompleted());
+        assertNotNull(closingResponse.getEventApplicants());
+        assertEquals(totalApplicants, closingResponse.getEventApplicants().size());
+
+        // 당첨자/낙첨자 상태 검증
+        List<EventApplicant> applicants = eventApplicantRepository.findByEvent(event);
+        int winnerCount = 0;
+        for (EventApplicant a : applicants) {
+            assertTrue(a.getApplicantStatus() == ApplicantStatus.WINNER ||
+                    a.getApplicantStatus() == ApplicantStatus.LOSER);
+            if (a.getApplicantStatus() == ApplicantStatus.WINNER) {
+                winnerCount++;
+            }
+        }
+        assertEquals(createdEvent.getNumberOfWinners(), winnerCount);
+    }
+
+//    3-2.이벤트에 응모자가 없는 경우
+    @Test
+    public void testCloseEventFailure_NoApplicants() {
+        EventResponseDto createdEvent = createTestEvent();
+
+        Exception exception = assertThrows(IllegalStateException.class, () -> {
+            eventService.closeEvent(createdEvent.getId());
+        });
+
+        assertTrue(exception.getMessage().contains("응모자가 없습니다."));
+    }
+
+    // -------------------- 4. cancelEvent 테스트 --------------------
+    @Test
+    public void testCancelEventSuccess() {
+        List<EventItemRequestDto> eventItemList = new ArrayList<>();
+        eventItemList.add(new EventItemRequestDto(testItem1.getId(), 2)); // 차감될 재고:2*당첨자수
+        EventRequestDto requestDto = EventRequestDto.builder()
+                .storeId(testStore.getId())
+                .numberOfWinners(3)
+                .participantCondition(ParticipantCondition.ALL_USERS.name())
+                .selectionMethod(SelectionMethod.RANDOM_DRAW.name())
+                .startDatetime(LocalDateTime.now().minusMinutes(1))
+                .endDatetime(LocalDateTime.now().plusDays(1))
+                .eventItemList(eventItemList)
+                .build();
+        EventResponseDto createdEvent = eventService.createEvent(requestDto);
+
+        eventService.cancelEvent(createdEvent.getId());
+
+        Event cancelledEvent = eventRepository.findById(createdEvent.getId()).orElseThrow();
+        assertTrue(cancelledEvent.getIsDeleted());
+
+        // 재고 복구 여부 확인 : 차감된 재고 만큼 복구되어야 함.
+        Item item1Reload = itemRepository.findById(testItem1.getId()).orElseThrow();
+        // 원래 잔여수량 100 - (2*3) 차감 후 cancel 에서 복구되므로 다시 100이어야 함.
+        assertEquals(100, item1Reload.getRemainingQuantity());
+    }
+
+//4-2. 마감된 이벤트 취소 시도
+@Test
+public void testCancelEventFailure_AlreadyCompleted() {
+    EventResponseDto createdEvent = createTestEvent();
+    Event event = eventRepository.findById(createdEvent.getId()).orElseThrow();
+    for (int i = 0; i < 10; i++) {
+        String uniqueSuffix = UUID.randomUUID().toString().substring(0, 3);
+        EventApplicant applicant = EventApplicant.builder()
+                .event(event)
+                .email("cancelApplicant" + uniqueSuffix + "@example.com")
+                .applicantName("지원자" + uniqueSuffix)
+                .applicantPassword("password")
+                .deliveryAddress("Address" + uniqueSuffix)
+                .applicantStatus(ApplicantStatus.WAITING)
+                .build();
+        eventApplicantRepository.save(applicant);
+    }
+
+    eventService.closeEvent(createdEvent.getId());
+
+    Exception ex = assertThrows(IllegalStateException.class, () -> {
+        eventService.cancelEvent(createdEvent.getId());
+    });
+    assertTrue(ex.getMessage().contains("이미 마감된 이벤트는 취소할 수 없습니다."));
+}
+
+    // -------------------- 5. confirmReceipt 테스트 --------------------
+    @Test
+    public void testConfirmReceiptSuccess() {
+        EventResponseDto createdEvent = createTestEvent();
+        Event event = eventRepository.findById(createdEvent.getId()).orElseThrow();
+
+        String uniqueSuffix = UUID.randomUUID().toString().substring(0, 3);
+        EventApplicant applicant = EventApplicant.builder()
+                .event(event)
+                .email("confirm" + uniqueSuffix + "@example.com")
+                .applicantName("지원자" + uniqueSuffix)
+                .applicantPassword("password")
+                .deliveryAddress("기존주소" + uniqueSuffix)
+                .applicantStatus(ApplicantStatus.WINNER) // WINNER 상태 세팅
+                .build();
+        EventApplicant savedApplicant = eventApplicantRepository.save(applicant);
+
+        // “수령 확정” 요청 DTO 준비
+        EventApplicantRequestDto updateRequest = EventApplicantRequestDto.builder()
+                .applicantName("변경된이름")
+                .deliveryAddress("변경된주소")
+                .build();
+
+        EventApplicantResponseDto updatedResponse = eventApplicantService.confirmReceipt(savedApplicant.getId(), updateRequest);
+
+        assertNotNull(updatedResponse);
+        assertEquals(savedApplicant.getId(), updatedResponse.getId());
+        assertEquals("변경된이름", updatedResponse.getApplicantName());
+        assertEquals("변경된주소", updatedResponse.getDeliveryAddress());
+        assertEquals(ApplicantStatus.CONFIRMED, updatedResponse.getApplicantStatus());
+    }
+
+//    5-2.당첨자 아닌데 수령 확정 시도
+    @Test
+    public void testConfirmReceiptFailure_NotWinner() {
+        EventResponseDto createdEvent = createTestEvent();
+        Event event = eventRepository.findById(createdEvent.getId()).orElseThrow();
+        String uniqueSuffix = UUID.randomUUID().toString().substring(0, 3);
+        EventApplicant applicant = EventApplicant.builder()
+                .event(event)
+                .email("nonWinner" + uniqueSuffix + "@example.com")
+                .applicantName("지원자" + uniqueSuffix)
+                .applicantPassword("password")
+                .deliveryAddress("주소" + uniqueSuffix)
+                .applicantStatus(ApplicantStatus.WAITING) // WINNER가 아님
+                .build();
+        EventApplicant savedApplicant = eventApplicantRepository.save(applicant);
+
+        EventApplicantRequestDto updateRequest = EventApplicantRequestDto.builder()
+                .applicantName("이름변경")
+                .deliveryAddress("주소변경")
+                .build();
+
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            eventApplicantService.confirmReceipt(savedApplicant.getId(), updateRequest);
+        });
+        assertTrue(exception.getMessage().contains("당첨(WINNER) 상태가 아닌 유저의 수령 확정은 불가능합니다."));
+    }
+
+
+    // 헬퍼 메서드: 테스트 이벤트 생성
+    private EventResponseDto createTestEvent() {
+        List<EventItemRequestDto> eventItemList = new ArrayList<>();
+        eventItemList.add(new EventItemRequestDto(testItem1.getId(), 10));
+        eventItemList.add(new EventItemRequestDto(testItem2.getId(), 3));
+
+        EventRequestDto eventRequestDto = EventRequestDto.builder()
+                .storeId(testStore.getId())
+                .numberOfWinners(5)
+                .participantCondition(ParticipantCondition.ALL_USERS.name())
+                .selectionMethod(SelectionMethod.RANDOM_DRAW.name())
+                .startDatetime(LocalDateTime.now().minusMinutes(1))
+                .endDatetime(LocalDateTime.now().plusDays(1))
+                .eventItemList(eventItemList)
+                .build();
+
+        return eventService.createEvent(eventRequestDto);
+    }
+
+}


### PR DESCRIPTION
## 목적 🎯 
핵심 로직 기능에서 유닛 테스트 코드 완성(Event, EventApplicant)

## 변경점 ✔️ 
이벤트 취소 로직 추가
로직상 필요한 예외처리 로직 추가(끝날짜는 생성보다 빠르게, 취소된 이벤트 처리 로직 추가)
EventResponseDto에서: EventItems → EventItemList
Event, EventApplicant의 모든 메서드에 유닛테스트 추가. 
 ⚙️ 자잘한 Validation 사항은  assertTrue, assertNotNull, assertEquals로 검증
 ⚙️ 에러 로직은 메시지로 일단 검증 → ⚠️ 추후 메시지 바꾸거나 하면 테스트 고장남

⚠️ 추후 로그인 과정 로직과 연결 필요


## 리뷰어에게 🙇 
가능하면 유닛 테스트 내용이 충분한지 검토해주세용
