### PR TITLE
:sparkles:feat:Add Pessimistic Lock

### DIFF
--- a/src/main/java/excluz/excluz/domain/event/event/repository/EventRepository.java
+++ b/src/main/java/excluz/excluz/domain/event/event/repository/EventRepository.java
@@ -1,10 +1,17 @@
 package excluz.excluz.domain.event.event.repository;
 
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import excluz.excluz.common.entity.Event;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface EventRepository extends JpaRepository<Event, Integer> {
-    Optional<Event> findByGeneratedCode(String generatedCode);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT e FROM Event e WHERE e.generatedCode = :code")
+    Optional<Event> findByGeneratedCode(@Param("code") String generatedCode);
 }

--- a/src/main/java/excluz/excluz/domain/event/eventApplicant/service/EventApplicantService.java
+++ b/src/main/java/excluz/excluz/domain/event/eventApplicant/service/EventApplicantService.java
@@ -24,6 +24,7 @@ public class EventApplicantService {
     private final EventApplicantRepository eventApplicantRepository;
     private final EventRepository eventRepository;
 
+    @Transactional // todo: 락 테스트
     public EventApplicantResponseDto applyForEvent(String code, EventApplicantRequestDto requestDto) {
         Event event = eventRepository.findByGeneratedCode(code)
                 .orElseThrow(() -> new IllegalArgumentException("잘못된 이벤트 코드입니다."));


### PR DESCRIPTION
## 목적 🎯 
동시성제어를 위한 락 기능 구현(1)

## 변경점 ✔️ 
EventRepository에 DB차원 비관적 락 걸음
동시성 테스트 충족 확인


## 리뷰어에게 🙇 
