### PR TITLE
♻️  refactor: edit userRole BackUp "ROLE_" and add delete prifix for "ROLE_"

### DIFF
--- a/src/main/java/excluz/excluz/auth/util/SecurityContextUtil.java
+++ b/src/main/java/excluz/excluz/auth/util/SecurityContextUtil.java
@@ -20,7 +20,9 @@ public class SecurityContextUtil {
 			return null;
 		}
 
-		return UserRole.valueOf(grantedAuthority.getAuthority());
+		String role = grantedAuthority.getAuthority().replace("ROLE_", "");
+
+		return UserRole.valueOf(role);
 	}
 
 	public static Integer getUserOrStreamerId() {

--- a/src/main/java/excluz/excluz/domain/user/enums/UserRole.java
+++ b/src/main/java/excluz/excluz/domain/user/enums/UserRole.java
@@ -6,9 +6,9 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum UserRole {
-	ADMIN("ADMIN", "관리자"), // 관리자
-	CUSTOMER("CUSTOMER", "일반 회원"), // 일반 회원
-	STREAMER("STREAMER", "굿즈 판매자") // 굿즈 판매자
+	ADMIN("ROLE_ADMIN", "관리자"), // 관리자
+	CUSTOMER("ROLE_CUSTOMER", "일반 회원"), // 일반 회원
+	STREAMER("ROLE_STREAMER", "굿즈 판매자") // 굿즈 판매자
 	;
 	private final String role;
 	private final String description;


### PR DESCRIPTION
## 목적
UserRole에서 ROLE_부분을 제거후 @Preauthorize 어노테이션이 작동하지 않는 것을 확인 이를 해결하기 위한 코드수정

## 변경점
UserRole의 모든 Enum값 이름 앞에 "ROLE_"을 복구
추가로 SecurityContextUtil의 getUserRole기능에 ROLE_을 떼는 로직 추가