### PR TITLE
:white_check_mark: test: Implement unit tests for CartItemService CRUD operations

### DIFF
--- a/src/main/java/excluz/excluz/domain/cartItem/controller/CartItemController.java
+++ b/src/main/java/excluz/excluz/domain/cartItem/controller/CartItemController.java
@@ -17,70 +17,76 @@ import excluz.excluz.domain.cartItem.dto.response.CartItemListResponseDto;
 import excluz.excluz.domain.cartItem.dto.response.CreateCartItemResponseDto;
 import excluz.excluz.domain.cartItem.dto.response.GetCartItemResponseDto;
 import excluz.excluz.domain.cartItem.service.CartItemService;
+import excluz.excluz.domain.user.enums.UserRole;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
-@RequestMapping("/api")
+@RequestMapping("/api/v1/cart-items")
 @RequiredArgsConstructor
 public class CartItemController {
 	private final CartItemService cartItemService;
 
 	// 물품 추가
-	@PostMapping("/v1/cart-items")
+	@PostMapping
 	public ResponseEntity<CreateCartItemResponseDto> addItemToCart(
 		@Valid @RequestBody CreateCartItemRequestDto requestDto
 	) {
 		Integer userId = SecurityContextUtil.getUserOrStreamerId();
+		UserRole userRole = SecurityContextUtil.getUserRole();
 
 		// 서비스단으로 userId와 리퀘스트 정보 넘기기
-		CreateCartItemResponseDto response = cartItemService.addItemToCart(userId, requestDto);
+		CreateCartItemResponseDto response = cartItemService.addItemToCart(userId, userRole, requestDto);
 
 		// HTTP 상태 코드 201(create)와 함께 CreateCartItemResponseDto 응답
 		return ResponseEntity.status(201).body(response);
 	}
 
 	// 물품 단건 조회
-	@GetMapping("/v1/cart-items/{cartItemId}")
+	@GetMapping("/{cartItemId}")
 	public ResponseEntity<GetCartItemResponseDto> getCartItem(
 		@PathVariable(name = "cartItemId") Integer cartItemId
 	) {
 		Integer userId = SecurityContextUtil.getUserOrStreamerId();
+		UserRole userRole = SecurityContextUtil.getUserRole();
 
-		GetCartItemResponseDto response = cartItemService.getCartItem(userId, cartItemId);
+		GetCartItemResponseDto response = cartItemService.getCartItem(userId, userRole, cartItemId);
 		return ResponseEntity.ok(response);
 	}
 
 	// 물품 다건 조회
-	@GetMapping("/v1/cart-items")
+	@GetMapping
 	public ResponseEntity<CartItemListResponseDto> getCartItemList() {
 		Integer userId = SecurityContextUtil.getUserOrStreamerId();
+		UserRole userRole = SecurityContextUtil.getUserRole();
 
-		CartItemListResponseDto response = cartItemService.getCartItemList(userId);
+		CartItemListResponseDto response = cartItemService.getCartItemList(userId, userRole);
 		return ResponseEntity.ok(response);
 	}
 
 	// 물품 개수 수정
-	@PatchMapping("/v1/cart-items/{cartItemId}")
+	@PatchMapping("/{cartItemId}")
 	public ResponseEntity<GetCartItemResponseDto> updateCartItemQuantity(
 		@PathVariable(name = "cartItemId") Integer cartItemId,
 		@Valid @RequestBody UpdateCartItemQuantityRequestDto requestDto
 	) {
 		Integer userId = SecurityContextUtil.getUserOrStreamerId();
+		UserRole userRole = SecurityContextUtil.getUserRole();
 
-		GetCartItemResponseDto response = cartItemService.updateCartItemQuantity(userId, cartItemId, requestDto);
+		GetCartItemResponseDto response = cartItemService.updateCartItemQuantity(userId, userRole, cartItemId, requestDto);
 		return ResponseEntity.ok(response);
 	}
 
 	// 물품 삭제(단건)
-	@DeleteMapping("/v1/cart-items/{cartItemId}")
+	@DeleteMapping("/{cartItemId}")
 	public ResponseEntity<Void> removeCartItem(
 		@PathVariable(name = "cartItemId") Integer cartItemId
 	) {
 		Integer userId = SecurityContextUtil.getUserOrStreamerId();
+		UserRole userRole = SecurityContextUtil.getUserRole();
 
 		// cartItemId를 서비스 단으로 넘겨서 검증 및 삭제 진행
-		cartItemService.removeCartItem(userId, cartItemId);
+		cartItemService.removeCartItem(userId, userRole, cartItemId);
 
 		// HTTP 상태 코드 204(No Content) 반환
 		return ResponseEntity.noContent().build();

--- a/src/main/java/excluz/excluz/domain/cartItem/dto/response/CreateCartItemResponseDto.java
+++ b/src/main/java/excluz/excluz/domain/cartItem/dto/response/CreateCartItemResponseDto.java
@@ -1,12 +1,27 @@
 package excluz.excluz.domain.cartItem.dto.response;
 
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 public class CreateCartItemResponseDto {
-	private final String message;
+	// 카트 아이템 아이디
+	private final Integer cartItemId;
 
-	public CreateCartItemResponseDto() {
-		this.message = "장바구니에 굿즈가 담겼습니다.";
+	// 개수
+	private final Integer quantity;
+
+	// 개당 가격(아이템 가격)
+	private final Integer itemPrice;
+
+	// 총 가격 (개당 가격 * 개수)
+	private final Integer totalItemPrice;
+
+	@Builder
+	public CreateCartItemResponseDto(Integer cartItemId, Integer quantity, Integer itemPrice) {
+		this.cartItemId = cartItemId;
+		this.quantity = quantity;
+		this.itemPrice = itemPrice;
+		this.totalItemPrice = itemPrice * quantity; // 개수 반영한 총 가격
 	}
 }

--- a/src/main/java/excluz/excluz/domain/cartItem/service/CartItemService.java
+++ b/src/main/java/excluz/excluz/domain/cartItem/service/CartItemService.java
@@ -32,8 +32,11 @@ public class CartItemService {
 	// 물품 추가
 	@Transactional
 	public CreateCartItemResponseDto addItemToCart(Integer userId, CreateCartItemRequestDto requestDto) {
+		// 유저 존재 여부 확인
 		User user = userRepository.findById(userId)
 			.orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND));
+
+		// 아이템 존재 여부 확인
 		Item item = itemRepository.findById(requestDto.getItemId())
 			.orElseThrow(() -> new NotFoundException(ErrorCode.ITEM_NOT_FOUND));
 
@@ -53,7 +56,11 @@ public class CartItemService {
 		cartItem.updateQuantity(newQuantity);
 		cartItemRepository.save(cartItem);
 
-		return new CreateCartItemResponseDto();
+		return CreateCartItemResponseDto.builder()
+			.cartItemId(cartItem.getId())
+			.quantity(cartItem.getQuantity())
+			.itemPrice(cartItem.getItem().getPrice())
+			.build();
 	}
 
 	// 물품 단건 조회

--- a/src/main/java/excluz/excluz/domain/cartItem/service/CartItemService.java
+++ b/src/main/java/excluz/excluz/domain/cartItem/service/CartItemService.java
@@ -139,6 +139,7 @@ public class CartItemService {
 
 		// 개수 업데이트 (기존 개수와 관계없이 사용자가 입력한 개수로 설정)
 		cartItem.updateQuantity(requestDto.getQuantity());
+		cartItemRepository.save(cartItem);
 
 		return GetCartItemResponseDto.builder()
 			.cartItemId(cartItem.getId())

--- a/src/main/java/excluz/excluz/domain/cartItem/service/CartItemService.java
+++ b/src/main/java/excluz/excluz/domain/cartItem/service/CartItemService.java
@@ -9,6 +9,7 @@ import excluz.excluz.common.entity.CartItem;
 import excluz.excluz.common.entity.Item;
 import excluz.excluz.common.entity.User;
 import excluz.excluz.common.exception.BadRequestException;
+import excluz.excluz.common.exception.ForbiddenException;
 import excluz.excluz.common.exception.NotFoundException;
 import excluz.excluz.common.exception.error.ErrorCode;
 import excluz.excluz.domain.cartItem.dto.request.CreateCartItemRequestDto;
@@ -18,6 +19,7 @@ import excluz.excluz.domain.cartItem.dto.response.CreateCartItemResponseDto;
 import excluz.excluz.domain.cartItem.dto.response.GetCartItemResponseDto;
 import excluz.excluz.domain.cartItem.repository.CartItemRepository;
 import excluz.excluz.domain.store.item.repository.ItemRepository;
+import excluz.excluz.domain.user.enums.UserRole;
 import excluz.excluz.domain.user.repository.UserRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -31,10 +33,15 @@ public class CartItemService {
 
 	// 물품 추가
 	@Transactional
-	public CreateCartItemResponseDto addItemToCart(Integer userId, CreateCartItemRequestDto requestDto) {
+	public CreateCartItemResponseDto addItemToCart(Integer userId, UserRole userRole, CreateCartItemRequestDto requestDto) {
 		// 유저 존재 여부 확인
 		User user = userRepository.findById(userId)
 			.orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND));
+
+		// 장바구니 이용은 CUSTOMER만 가능
+		if (userRole != UserRole.CUSTOMER) {
+			throw new ForbiddenException(ErrorCode.FORBIDDEN_USER_ACCESS);
+		}
 
 		// 아이템 존재 여부 확인
 		Item item = itemRepository.findById(requestDto.getItemId())
@@ -64,9 +71,15 @@ public class CartItemService {
 	}
 
 	// 물품 단건 조회
-	public GetCartItemResponseDto getCartItem(Integer userId, Integer cartItemId) {
+	public GetCartItemResponseDto getCartItem(Integer userId, UserRole userRole, Integer cartItemId) {
+		// 장바구니 이용은 CUSTOMER만 가능
+		if (userRole != UserRole.CUSTOMER) {
+			throw new ForbiddenException(ErrorCode.FORBIDDEN_USER_ACCESS);
+		}
+
+		// 장바구니에서 해당 아이템 찾기
 		CartItem cartItem = cartItemRepository.findByIdAndUserId(cartItemId, userId)
-			.orElseThrow(() -> new NotFoundException(ErrorCode.ITEM_NOT_FOUND));
+			.orElseThrow(() -> new NotFoundException(ErrorCode.CART_ITEM_NOT_FOUND));
 
 		return GetCartItemResponseDto.builder()
 			.cartItemId(cartItem.getId())
@@ -76,7 +89,12 @@ public class CartItemService {
 	}
 
 	// 물품 다건 조회
-	public CartItemListResponseDto getCartItemList(Integer userId) {
+	public CartItemListResponseDto getCartItemList(Integer userId, UserRole userRole) {
+		// 장바구니 이용은 CUSTOMER만 가능
+		if (userRole != UserRole.CUSTOMER) {
+			throw new ForbiddenException(ErrorCode.FORBIDDEN_USER_ACCESS);
+		}
+
 		List<CartItem> cartItems = cartItemRepository.findByUserId(userId);
 
 		List<GetCartItemResponseDto> cartItemList = cartItems.stream()
@@ -95,9 +113,15 @@ public class CartItemService {
 	@Transactional
 	public GetCartItemResponseDto updateCartItemQuantity(
 		Integer userId,
+		UserRole userRole,
 		Integer cartItemId,
 		UpdateCartItemQuantityRequestDto requestDto
 	) {
+		// 장바구니 이용은 CUSTOMER만 가능
+		if (userRole != UserRole.CUSTOMER) {
+			throw new ForbiddenException(ErrorCode.FORBIDDEN_USER_ACCESS);
+		}
+
 		// 장바구니에서 해당 아이템 찾기
 		CartItem cartItem = cartItemRepository.findByIdAndUserId(cartItemId, userId)
 			.orElseThrow(() -> new NotFoundException(ErrorCode.CART_ITEM_NOT_FOUND));
@@ -125,7 +149,13 @@ public class CartItemService {
 
 	// 물품 삭제(단건)
 	@Transactional
-	public void removeCartItem(Integer userId, Integer cartItemId) {
+	public void removeCartItem(Integer userId, UserRole userRole, Integer cartItemId) {
+		// 장바구니 이용은 CUSTOMER만 가능
+		if (userRole != UserRole.CUSTOMER) {
+			throw new ForbiddenException(ErrorCode.FORBIDDEN_USER_ACCESS);
+		}
+
+		// 장바구니에서 해당 아이템 찾기
 		CartItem cartItem = cartItemRepository.findByIdAndUserId(cartItemId, userId)
 			.orElseThrow(() -> new NotFoundException(ErrorCode.CART_ITEM_NOT_FOUND));
 

--- a/src/test/java/excluz/excluz/domain/cartItem/service/CartItemServiceTest.java
+++ b/src/test/java/excluz/excluz/domain/cartItem/service/CartItemServiceTest.java
@@ -98,7 +98,7 @@ class CartItemServiceTest {
 	}
 
 	@Test
-	@DisplayName("success: 재고와 동일한 수량을 장바구니에 추가")
+	@DisplayName("success: 요청 수량 = 재고")
 	void addItemToCart_success_matchingStockQuantity_case_1() {
 		// given
 		User user = mock(User.class);
@@ -136,7 +136,7 @@ class CartItemServiceTest {
 	}
 
 	@Test
-	@DisplayName("success: 장바구니에 있는 개수 + 추가 요청 개수 = 재고")
+	@DisplayName("success: 장바구니에 있는 수량 + 추가 요청 수량 = 재고")
 	void addItemToCart_success_matchingStockQuantity_case_2() {
 		// given
 		User user = mock(User.class);
@@ -188,7 +188,7 @@ class CartItemServiceTest {
 
 		// when, then
 		Assertions.assertThatThrownBy(() -> cartItemService.addItemToCart(userId, userRole, requestDto))
-			.isInstanceOf(NotFoundException.class);
+			.isInstanceOf(NotFoundException.class); // NotFoundException 예외 발생
 	}
 
 	@Test
@@ -207,7 +207,7 @@ class CartItemServiceTest {
 
 		// when, then
 		Assertions.assertThatThrownBy(() -> cartItemService.addItemToCart(userId, userRole, requestDto))
-			.isInstanceOf(NotFoundException.class);
+			.isInstanceOf(NotFoundException.class); // NotFoundException 예외 발생
 	}
 
 	@Test
@@ -238,7 +238,7 @@ class CartItemServiceTest {
 
 		// when, then
 		Assertions.assertThatThrownBy(() -> cartItemService.addItemToCart(userId, userRole, requestDto))
-			.isInstanceOf(BadRequestException.class);
+			.isInstanceOf(BadRequestException.class); // BadRequestException 예외 발생
 	}
 
 	@Test
@@ -269,7 +269,7 @@ class CartItemServiceTest {
 
 		// when, then
 		Assertions.assertThatThrownBy(() -> cartItemService.addItemToCart(userId, userRole, requestDto))
-			.isInstanceOf(BadRequestException.class);
+			.isInstanceOf(BadRequestException.class); // BadRequestException 예외 발생
 	}
 
 	@Test
@@ -286,7 +286,7 @@ class CartItemServiceTest {
 
 		// when, then
 		Assertions.assertThatThrownBy(() -> cartItemService.addItemToCart(userId, userRole, requestDto))
-			.isInstanceOf(ForbiddenException.class);
+			.isInstanceOf(ForbiddenException.class); // ForbiddenException 예외 발생
 	}
 
 
@@ -347,7 +347,7 @@ class CartItemServiceTest {
 
 		// when, then
 		Assertions.assertThatThrownBy(() -> cartItemService.getCartItem(user.getId(), userRole, cartItemId))
-			.isInstanceOf(NotFoundException.class);
+			.isInstanceOf(NotFoundException.class); // NotFoundException 예외 발생
 	}
 
 	@Test
@@ -360,7 +360,7 @@ class CartItemServiceTest {
 
 		// when, then
 		Assertions.assertThatThrownBy(() -> cartItemService.getCartItem(userId, userRole, cartItemId))
-			.isInstanceOf(ForbiddenException.class);
+			.isInstanceOf(ForbiddenException.class); // ForbiddenException 예외 발생
 	}
 
 	@Test
@@ -416,7 +416,7 @@ class CartItemServiceTest {
 
 		// when, then
 		Assertions.assertThatThrownBy(() -> cartItemService.getCartItem(userA.getId(), userRole, cartItem.getId()))
-			.isInstanceOf(NotFoundException.class);
+			.isInstanceOf(NotFoundException.class); // NotFoundException 예외 발생
 	}
 
 
@@ -472,7 +472,6 @@ class CartItemServiceTest {
 		Assertions.assertThat(result).isNotNull(); // 결과가 null이 아닌지 확인
 		Assertions.assertThat(result.getCartItemList()).hasSize(2); // 장바구니에 2개 아이템 있는지 확인
 		Assertions.assertThat(result.getTotalPrice()).isEqualTo(800); // (100*2 + 200*3) = 800 확인
-
 		Assertions.assertThat(result.getCartItemList().get(0).getQuantity()).isEqualTo(2); // 첫 번째 아이템 개수 확인
 		Assertions.assertThat(result.getCartItemList().get(1).getQuantity()).isEqualTo(3); // 두 번째 아이템 개수 확인
 	}
@@ -505,7 +504,7 @@ class CartItemServiceTest {
 
 		// when, then
 		Assertions.assertThatThrownBy(() -> cartItemService.getCartItemList(userId, userRole))
-			.isInstanceOf(ForbiddenException.class);
+			.isInstanceOf(ForbiddenException.class); // ForbiddenException 예외 발생
 	}
 
 
@@ -531,20 +530,20 @@ class CartItemServiceTest {
 			10     // quantity: 10 (현재 장바구니에 담긴 수량)
 		);
 
-		Integer userId = 1;
 		UserRole userRole = UserRole.CUSTOMER;
-		Integer cartItemId = 1;
+		ReflectionTestUtils.setField(user, "id", 1);
+		ReflectionTestUtils.setField(cartItem, "id", 1);
 
-		when(cartItemRepository.findByIdAndUserId(cartItemId, userId))
+		when(cartItemRepository.findByIdAndUserId(cartItem.getId(), user.getId()))
 			.thenReturn(Optional.of(cartItem));
 
 		UpdateCartItemQuantityRequestDto requestDto = new UpdateCartItemQuantityRequestDto(1); // 개수 수정
 
 		// when, then
 		Assertions.assertThatCode(() -> cartItemService.updateCartItemQuantity(
-				userId,
+				user.getId(),
 				userRole,
-				cartItemId,
+				cartItem.getId(),
 				requestDto // 업데이트할 장바구니 아이템 정보
 			))
 			.doesNotThrowAnyException(); // 예외 발생하지 않아야 함
@@ -569,22 +568,45 @@ class CartItemServiceTest {
 			10     // quantity: 10 (현재 장바구니에 담긴 수량)
 		);
 
-		Integer userId = 1;
 		UserRole userRole = UserRole.CUSTOMER;
-		Integer cartItemId = 1;
+		ReflectionTestUtils.setField(user, "id", 1);
+		ReflectionTestUtils.setField(cartItem, "id", 1);
 
-		when(cartItemRepository.findByIdAndUserId(cartItemId, userId))
+		when(cartItemRepository.findByIdAndUserId(cartItem.getId(), user.getId()))
 			.thenReturn(Optional.of(cartItem));
 
 		UpdateCartItemQuantityRequestDto requestDto = new UpdateCartItemQuantityRequestDto(100); // 100개로 개수 수정
 
 		// when, then
 		Assertions.assertThatThrownBy(() -> cartItemService.updateCartItemQuantity(
+				user.getId(),
+				userRole,
+				cartItem.getId(),
+				requestDto // 업데이트할 장바구니 아이템 정보
+			))
+			.isInstanceOf(BadRequestException.class); // BadRequestException 예외 발생
+	}
+
+	@Test
+	@DisplayName("fail: 존재하지 않는 장바구니 아이템 (예외 발생)")
+	void updateCartItemQuantity_fail_cartItemNotFound() {
+		// given
+		Integer userId = 1;
+		UserRole userRole = UserRole.CUSTOMER;
+		Integer cartItemId = 999; // 존재하지 않는 ID
+
+		when(cartItemRepository.findByIdAndUserId(cartItemId, userId))
+			.thenReturn(Optional.empty()); // 해당 장바구니 아이템 없음
+
+		UpdateCartItemQuantityRequestDto requestDto = new UpdateCartItemQuantityRequestDto(5); // 5개로 변경 요청
+
+		// when, then
+		Assertions.assertThatThrownBy(() -> cartItemService.updateCartItemQuantity(
 				userId,
 				userRole,
 				cartItemId,
-				requestDto // 업데이트할 장바구니 아이템 정보
+				requestDto
 			))
-			.isInstanceOf(BadRequestException.class);
+			.isInstanceOf(NotFoundException.class); // NotFoundException 예외 발생
 	}
 }

--- a/src/test/java/excluz/excluz/domain/cartItem/service/CartItemServiceTest.java
+++ b/src/test/java/excluz/excluz/domain/cartItem/service/CartItemServiceTest.java
@@ -55,7 +55,7 @@ class CartItemServiceTest {
 	 */
 	@Test
 	@DisplayName("success: 장바구니 아이템 추가")
-	void addItemToCart_success() {
+	void addItemToCart() {
 		// given
 		User user = mock(User.class);
 		Item item = new Item(
@@ -99,7 +99,7 @@ class CartItemServiceTest {
 
 	@Test
 	@DisplayName("success: 요청 수량 = 재고")
-	void addItemToCart_success_matchingStockQuantity_case_1() {
+	void addItemToCartMatchingStockQuantityCase1() {
 		// given
 		User user = mock(User.class);
 		Item item = new Item(
@@ -137,7 +137,7 @@ class CartItemServiceTest {
 
 	@Test
 	@DisplayName("success: 장바구니에 있는 수량 + 추가 요청 수량 = 재고")
-	void addItemToCart_success_matchingStockQuantity_case_2() {
+	void addItemToCartMatchingStockQuantityCase2() {
 		// given
 		User user = mock(User.class);
 		Item item = new Item(
@@ -175,7 +175,7 @@ class CartItemServiceTest {
 
 	@Test
 	@DisplayName("fail: 물품 추가 시 존재하지 않는 유저 (예외 발생)")
-	void addItemToCart_fail_userNotFound() {
+	void addItemToCartUserNotFound() {
 		// given
 		Integer userId = 1;
 		UserRole userRole = UserRole.CUSTOMER;
@@ -193,7 +193,7 @@ class CartItemServiceTest {
 
 	@Test
 	@DisplayName("fail: 물품 추가 시 존재하지 않는 아이템 (예외 발생)")
-	void addItemToCart_fail_itemNotFound() {
+	void addItemToCartItemNotFound() {
 		// given
 		Integer userId = 1;
 		UserRole userRole = UserRole.CUSTOMER;
@@ -212,7 +212,7 @@ class CartItemServiceTest {
 
 	@Test
 	@DisplayName("fail: 요청 개수 > 재고 (예외 발생)")
-	void addItemToCart_fail_stockExceeded_case_1() {
+	void addItemToCartStockExceededCase1() {
 		// given
 		User user = mock(User.class);
 		Item item = new Item(
@@ -243,7 +243,7 @@ class CartItemServiceTest {
 
 	@Test
 	@DisplayName("fail: 기 요청 개수 + 새로운 요청 개수 > 재고 (예외 발생)")
-	void addItemToCart_fail_stockExceeded_case_2() {
+	void addItemToCartStockExceededCase2() {
 		// given
 		User user = mock(User.class);
 		Item item = new Item(
@@ -274,7 +274,7 @@ class CartItemServiceTest {
 
 	@Test
 	@DisplayName("fail: 유효하지 않은 유저 역할 (예외 발생)")
-	void addItemToCart_fail_invalidUserRole() {
+	void addItemToCartInvalidUserRole() {
 		// given
 		Integer userId = 1;
 		UserRole userRole = UserRole.STREAMER; // CUSTOMER가 아닌 경우
@@ -295,7 +295,7 @@ class CartItemServiceTest {
 	 */
 	@Test
 	@DisplayName("success: 장바구니 아이템 단건 조회")
-	void getCartItem_success() {
+	void getCartItem() {
 		// given
 		User user = mock(User.class);
 		Store store = mock(Store.class);
@@ -335,7 +335,7 @@ class CartItemServiceTest {
 
 	@Test
 	@DisplayName("fail: 존재하지 않는 장바구니 아이템 ID (예외 발생)")
-	void getCartItem_fail_notFound() {
+	void getCartItemNotFound() {
 		// given
 		User user = mock(User.class);
 		ReflectionTestUtils.setField(user, "id", 1); // user id 값을 1로 세팅
@@ -352,7 +352,7 @@ class CartItemServiceTest {
 
 	@Test
 	@DisplayName("fail: 유효하지 않은 유저 역할 (예외 발생)")
-	void getCartItem_fail_invalidUserRole() {
+	void getCartItemInvalidUserRole() {
 		// given
 		Integer userId = 1;
 		Integer cartItemId = 1;
@@ -365,7 +365,7 @@ class CartItemServiceTest {
 
 	@Test
 	@DisplayName("fail: 다른 유저의 장바구니 아이템 조회 시 예외 발생")
-	void getCartItem_fail_wrongUser() {
+	void getCartItemWrongUser() {
 		// given
 		User userA = User.builder()
 			.name("유저A")
@@ -425,7 +425,7 @@ class CartItemServiceTest {
 	 */
 	@Test
 	@DisplayName("success: 장바구니 아이템 목록 조회")
-	void getCartItemList_success() {
+	void getCartItemList() {
 		// given
 		User user = mock(User.class);
 		Store store = mock(Store.class);
@@ -478,7 +478,7 @@ class CartItemServiceTest {
 
 	@Test
 	@DisplayName("success: 장바구니가 비어있는 경우")
-	void getCartItemList_success_emptyCart() {
+	void getCartItemListEmptyCart() {
 		// given
 		Integer userId = 1;
 		UserRole userRole = UserRole.CUSTOMER;
@@ -497,7 +497,7 @@ class CartItemServiceTest {
 
 	@Test
 	@DisplayName("fail: 유효하지 않은 유저 역할 (예외 발생)")
-	void getCartItemList_fail_invalidUserRole() {
+	void getCartItemListInvalidUserRole() {
 		// given
 		Integer userId = 1;
 		UserRole userRole = UserRole.STREAMER; // CUSTOMER가 아닌 경우
@@ -514,7 +514,7 @@ class CartItemServiceTest {
 	 */
 	@Test
 	@DisplayName("success: 요청 개수 < 재고")
-	void updateCartItemQuantity_success() {
+	void updateCartItemQuantity() {
 		// given
 		User user = mock(User.class);
 		Item item = new Item(
@@ -552,7 +552,7 @@ class CartItemServiceTest {
 
 	@Test
 	@DisplayName("fail: 요청 개수 > 재고 (예외 발생)")
-	void updateCartItemQuantity_fail() {
+	void updateCartItemQuantityBadRequest() {
 		// given
 		User user = mock(User.class);
 		Item item = new Item(
@@ -589,7 +589,7 @@ class CartItemServiceTest {
 
 	@Test
 	@DisplayName("fail: 존재하지 않는 장바구니 아이템 (예외 발생)")
-	void updateCartItemQuantity_fail_cartItemNotFound() {
+	void updateCartItemQuantityCartItemNotFound() {
 		// given
 		Integer userId = 1;
 		UserRole userRole = UserRole.CUSTOMER;
@@ -616,7 +616,7 @@ class CartItemServiceTest {
 	 */
 	@Test
 	@DisplayName("success: 장바구니 아이템 삭제")
-	void removeCartItem_success() {
+	void removeCartItem() {
 		// given
 		User user = mock(User.class);
 		Store store = mock(Store.class);
@@ -652,7 +652,7 @@ class CartItemServiceTest {
 
 	@Test
 	@DisplayName("fail: 존재하지 않는 장바구니 아이템 삭제 (예외 발생)")
-	void removeCartItem_fail_cartItemNotFound() {
+	void removeCartItemCartItemNotFound() {
 		// given
 		Integer userId = 1;
 		UserRole userRole = UserRole.CUSTOMER;
@@ -668,7 +668,7 @@ class CartItemServiceTest {
 
 	@Test
 	@DisplayName("fail: 유효하지 않은 유저 역할 (예외 발생)")
-	void removeCartItem_fail_invalidUserRole() {
+	void removeCartItemInvalidUserRole() {
 		// given
 		Integer userId = 1;
 		Integer cartItemId = 1;

--- a/src/test/java/excluz/excluz/domain/cartItem/service/CartItemServiceTest.java
+++ b/src/test/java/excluz/excluz/domain/cartItem/service/CartItemServiceTest.java
@@ -42,6 +42,9 @@ class CartItemServiceTest {
 	@InjectMocks
 	private CartItemService cartItemService;
 
+	/*
+	 * addItemToCart
+	 */
 	@Test
 	@DisplayName("success: 장바구니에 아이템 추가 메서드")
 	void addItemToCart_success() {
@@ -242,6 +245,19 @@ class CartItemServiceTest {
 			.isInstanceOf(BadRequestException.class);
 	}
 
+	/*
+	 * getCartItem
+	 */
+
+
+	/*
+	 * getCartItemList
+	 */
+
+
+	/*
+	 * updateCartItemQuantity
+	 */
 	@Test
 	@DisplayName("success: 요청 개수 < 재고")
 	void updateCartItemQuantity_success() {

--- a/src/test/java/excluz/excluz/domain/cartItem/service/CartItemServiceTest.java
+++ b/src/test/java/excluz/excluz/domain/cartItem/service/CartItemServiceTest.java
@@ -649,4 +649,22 @@ class CartItemServiceTest {
 		// then
 		verify(cartItemRepository, times(1)).delete(cartItem); // delete() 메서드가 1번 호출되었는지 확인
 	}
+
+	@Test
+	@DisplayName("fail: 존재하지 않는 장바구니 아이템 삭제 (예외 발생)")
+	void removeCartItem_fail_cartItemNotFound() {
+		// given
+		Integer userId = 1;
+		UserRole userRole = UserRole.CUSTOMER;
+		Integer cartItemId = 999; // 존재하지 않는 ID
+
+		when(cartItemRepository.findByIdAndUserId(cartItemId, userId))
+			.thenReturn(Optional.empty()); // 해당 장바구니 아이템 없음
+
+		// when, then
+		Assertions.assertThatThrownBy(() -> cartItemService.removeCartItem(userId, userRole, cartItemId))
+			.isInstanceOf(NotFoundException.class); // NotFoundException 예외 발생
+	}
+
+
 }

--- a/src/test/java/excluz/excluz/domain/cartItem/service/CartItemServiceTest.java
+++ b/src/test/java/excluz/excluz/domain/cartItem/service/CartItemServiceTest.java
@@ -18,6 +18,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import excluz.excluz.common.entity.CartItem;
 import excluz.excluz.common.entity.Item;
 import excluz.excluz.common.entity.Store;
+import excluz.excluz.common.entity.Streamer;
 import excluz.excluz.common.entity.User;
 import excluz.excluz.common.exception.BadRequestException;
 import excluz.excluz.common.exception.ForbiddenException;
@@ -360,6 +361,62 @@ class CartItemServiceTest {
 		// when, then
 		Assertions.assertThatThrownBy(() -> cartItemService.getCartItem(userId, userRole, cartItemId))
 			.isInstanceOf(ForbiddenException.class);
+	}
+
+	@Test
+	@DisplayName("fail: 다른 유저의 장바구니 아이템 조회 시 예외 발생")
+	void getCartItem_fail_wrongUser() {
+		// given
+		User userA = User.builder()
+			.name("유저A")
+			.nickName("userA")
+			.phoneNumber("010-1111-1111")
+			.address("서울시 강남구")
+			.email("userA@example.com")
+			.password("passwordA!!!!!!!!!")
+			.build();
+
+		User userB = User.builder()
+			.name("유저B")
+			.nickName("userB")
+			.phoneNumber("010-2222-2222")
+			.address("서울시 서초구")
+			.email("userB@example.com")
+			.password("passwordB!!!!!!!!!")
+			.build();
+
+		ReflectionTestUtils.setField(userA, "id", 1);
+		ReflectionTestUtils.setField(userB, "id", 2);
+
+		Streamer streamer = new Streamer(); // Streamer 객체
+		ReflectionTestUtils.setField(streamer, "id", 1); // Streamer의 ID 설정
+
+		Store store = Store.builder()
+			.streamer(streamer) // streamer: 위에서 생성한 streamer 객체
+			.address("서울시 강남구") // 스토어 주소
+			.storeName("테스트 스토어") // 스토어 이름
+			.registrationNumber("123-45-67890") // 사업자 등록번호
+			.build();
+
+		Item item = new Item(
+			store,         // store: 위에서 생성한 store 객체
+			"itemName",   // itemName: "itemName" (상품명)
+			"test",       // explanation: "test" (설명)
+			100,          // price: 100 (상품 가격)
+			10            // remainingQuantity: 10 (재고 개수)
+		);
+
+		CartItem cartItem = new CartItem(userB, item, 5); // userB의 장바구니 아이템
+		ReflectionTestUtils.setField(cartItem, "id", 1); // cartItemId 설정
+
+		UserRole userRole = UserRole.CUSTOMER;
+
+		when(cartItemRepository.findByIdAndUserId(1, 1))
+			.thenReturn(Optional.empty()); // userA의 ID로는 userB의 장바구니 아이템 조회 불가능
+
+		// when, then
+		Assertions.assertThatThrownBy(() -> cartItemService.getCartItem(userA.getId(), userRole, cartItem.getId()))
+			.isInstanceOf(NotFoundException.class);
 	}
 
 

--- a/src/test/java/excluz/excluz/domain/cartItem/service/CartItemServiceTest.java
+++ b/src/test/java/excluz/excluz/domain/cartItem/service/CartItemServiceTest.java
@@ -609,4 +609,44 @@ class CartItemServiceTest {
 			))
 			.isInstanceOf(NotFoundException.class); // NotFoundException 예외 발생
 	}
+
+
+	/*
+	 * removeCartItem
+	 */
+	@Test
+	@DisplayName("success: 장바구니 아이템 삭제")
+	void removeCartItem_success() {
+		// given
+		User user = mock(User.class);
+		Store store = mock(Store.class);
+		Item item = new Item(
+			store,         // store: 위에서 생성한 store 객체
+			"itemName",   // itemName: "itemName" (상품명)
+			"test",       // explanation: "test" (설명)
+			100,          // price: 100 (상품 가격)
+			10            // remainingQuantity: 10 (재고 개수)
+		);
+		CartItem cartItem = new CartItem(
+			user,  // user: 위에서 생성한 user 객체
+			item,  // item: 위에서 생성한 Item 객체
+			10     // quantity: 10 (현재 장바구니에 담긴 수량)
+		);
+
+		ReflectionTestUtils.setField(user, "id", 1);
+		ReflectionTestUtils.setField(cartItem, "id", 1);
+
+		Integer userId = user.getId();
+		UserRole userRole = UserRole.CUSTOMER;
+		Integer cartItemId = cartItem.getId();
+
+		when(cartItemRepository.findByIdAndUserId(cartItemId, userId))
+			.thenReturn(Optional.of(cartItem)); // 장바구니 아이템 찾기 성공
+
+		// when
+		cartItemService.removeCartItem(userId, userRole, cartItemId);
+
+		// then
+		verify(cartItemRepository, times(1)).delete(cartItem); // delete() 메서드가 1번 호출되었는지 확인
+	}
 }

--- a/src/test/java/excluz/excluz/domain/cartItem/service/CartItemServiceTest.java
+++ b/src/test/java/excluz/excluz/domain/cartItem/service/CartItemServiceTest.java
@@ -285,6 +285,7 @@ class CartItemServiceTest {
 			.isInstanceOf(ForbiddenException.class);
 	}
 
+
 	/*
 	 * getCartItem
 	 */
@@ -343,6 +344,19 @@ class CartItemServiceTest {
 		// when, then
 		Assertions.assertThatThrownBy(() -> cartItemService.getCartItem(user.getId(), userRole, cartItemId))
 			.isInstanceOf(NotFoundException.class);
+	}
+
+	@Test
+	@DisplayName("fail: 유효하지 않은 유저 역할 (예외 발생)")
+	void getCartItem_fail_invalidUserRole() {
+		// given
+		Integer userId = 1;
+		Integer cartItemId = 1;
+		UserRole userRole = UserRole.STREAMER; // 유효하지 않은 유저 역할 (CUSTOMER가 아님)
+
+		// when, then
+		Assertions.assertThatThrownBy(() -> cartItemService.getCartItem(userId, userRole, cartItemId))
+			.isInstanceOf(ForbiddenException.class);
 	}
 
 

--- a/src/test/java/excluz/excluz/domain/cartItem/service/CartItemServiceTest.java
+++ b/src/test/java/excluz/excluz/domain/cartItem/service/CartItemServiceTest.java
@@ -328,6 +328,22 @@ class CartItemServiceTest {
 		Assertions.assertThat(result.getTotalItemPrice()).isEqualTo(1000); // 총 가격(단가 * 개수)이 올바르게 계산되었는지 확인
 	}
 
+	@Test
+	@DisplayName("fail: 존재하지 않는 장바구니 아이템 ID (예외 발생)")
+	void getCartItem_fail_notFound() {
+		// given
+		User user = mock(User.class);
+		ReflectionTestUtils.setField(user, "id", 1); // user id 값을 1로 세팅
+		UserRole userRole = UserRole.CUSTOMER;
+		Integer cartItemId = 999; // 존재하지 않는 ID
+
+		when(cartItemRepository.findByIdAndUserId(cartItemId, user.getId()))
+			.thenReturn(Optional.empty()); // 없는 데이터
+
+		// when, then
+		Assertions.assertThatThrownBy(() -> cartItemService.getCartItem(user.getId(), userRole, cartItemId))
+			.isInstanceOf(NotFoundException.class);
+	}
 
 
 	/*

--- a/src/test/java/excluz/excluz/domain/cartItem/service/CartItemServiceTest.java
+++ b/src/test/java/excluz/excluz/domain/cartItem/service/CartItemServiceTest.java
@@ -2,6 +2,7 @@ package excluz.excluz.domain.cartItem.service;
 
 import static org.mockito.Mockito.*;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -417,6 +418,25 @@ class CartItemServiceTest {
 
 		Assertions.assertThat(result.getCartItemList().get(0).getQuantity()).isEqualTo(2); // 첫 번째 아이템 개수 확인
 		Assertions.assertThat(result.getCartItemList().get(1).getQuantity()).isEqualTo(3); // 두 번째 아이템 개수 확인
+	}
+
+	@Test
+	@DisplayName("success: 장바구니가 비어있는 경우")
+	void getCartItemList_success_emptyCart() {
+		// given
+		Integer userId = 1;
+		UserRole userRole = UserRole.CUSTOMER;
+
+		when(cartItemRepository.findByUserId(userId))
+			.thenReturn(Collections.emptyList()); // 빈 리스트 반환
+
+		// when
+		CartItemListResponseDto result = cartItemService.getCartItemList(userId, userRole);
+
+		// then
+		Assertions.assertThat(result).isNotNull();
+		Assertions.assertThat(result.getCartItemList()).isEmpty(); // 빈 리스트인지 확인
+		Assertions.assertThat(result.getTotalPrice()).isEqualTo(0); // 총 가격이 0인지 확인
 	}
 
 	@Test

--- a/src/test/java/excluz/excluz/domain/cartItem/service/CartItemServiceTest.java
+++ b/src/test/java/excluz/excluz/domain/cartItem/service/CartItemServiceTest.java
@@ -11,9 +11,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import excluz.excluz.common.entity.CartItem;
 import excluz.excluz.common.entity.Item;
+import excluz.excluz.common.entity.Store;
 import excluz.excluz.common.entity.User;
 import excluz.excluz.common.exception.BadRequestException;
 import excluz.excluz.common.exception.ForbiddenException;
@@ -21,6 +23,7 @@ import excluz.excluz.common.exception.NotFoundException;
 import excluz.excluz.domain.cartItem.dto.request.CreateCartItemRequestDto;
 import excluz.excluz.domain.cartItem.dto.request.UpdateCartItemQuantityRequestDto;
 import excluz.excluz.domain.cartItem.dto.response.CreateCartItemResponseDto;
+import excluz.excluz.domain.cartItem.dto.response.GetCartItemResponseDto;
 import excluz.excluz.domain.cartItem.repository.CartItemRepository;
 import excluz.excluz.domain.store.item.repository.ItemRepository;
 import excluz.excluz.domain.user.enums.UserRole;
@@ -47,7 +50,7 @@ class CartItemServiceTest {
 	 * addItemToCart
 	 */
 	@Test
-	@DisplayName("success: 장바구니에 아이템 추가 메서드")
+	@DisplayName("success: 장바구니 아이템 추가")
 	void addItemToCart_success() {
 		// given
 		User user = mock(User.class);
@@ -285,12 +288,51 @@ class CartItemServiceTest {
 	/*
 	 * getCartItem
 	 */
+	@Test
+	@DisplayName("success: 장바구니 아이템 단건 조회")
+	void getCartItem_success() {
+		// given
+		User user = mock(User.class);
+		Store store = mock(Store.class);
+		Item item = new Item(
+			store,         // store: 위에서 생성한 store 객체
+			"itemName",   // itemName: "itemName" (상품명)
+			"test",       // explanation: "test" (설명)
+			100,          // price: 100 (상품 가격)
+			10            // remainingQuantity: 10 (재고 개수)
+		);
+		CartItem cartItem = new CartItem(
+			user,  // user: 위에서 생성한 user 객체
+			item,  // item: 위에서 생성한 Item 객체
+			10     // quantity: 10 (현재 장바구니에 담긴 수량)
+		);
+
+		ReflectionTestUtils.setField(user, "id", 1); // user id 값을 1로 세팅
+		ReflectionTestUtils.setField(cartItem, "id", 1); // cartItem id 값을 1로 세팅
+
+		UserRole userRole = UserRole.CUSTOMER;
+
+		when(cartItemRepository.findByIdAndUserId(cartItem.getId(), user.getId()))
+			.thenReturn(Optional.of(cartItem));
+
+		// when
+		GetCartItemResponseDto result = cartItemService.getCartItem(user.getId(), userRole, cartItem.getId());
+
+		// then
+		verify(cartItemRepository, times(1)).findByIdAndUserId(cartItem.getId(), user.getId()); // findByIdAndUserId()가 1번 호출되었는지 확인
+
+		Assertions.assertThat(result).isNotNull(); // 반환된 응답 객체가 null이 아닌지 확인
+		Assertions.assertThat(result.getCartItemId()).isEqualTo(cartItem.getId()); // 요청한 cartItemId와 동일한지 확인
+		Assertions.assertThat(result.getQuantity()).isEqualTo(10); // 장바구니에 담긴 개수가 요청한 수량과 일치하는지 확인
+		Assertions.assertThat(result.getItemPrice()).isEqualTo(100); // 아이템의 단가가 예상 값과 일치하는지 확인
+		Assertions.assertThat(result.getTotalItemPrice()).isEqualTo(1000); // 총 가격(단가 * 개수)이 올바르게 계산되었는지 확인
+	}
+
 
 
 	/*
 	 * getCartItemList
 	 */
-
 
 	/*
 	 * updateCartItemQuantity

--- a/src/test/java/excluz/excluz/domain/cartItem/service/CartItemServiceTest.java
+++ b/src/test/java/excluz/excluz/domain/cartItem/service/CartItemServiceTest.java
@@ -419,6 +419,17 @@ class CartItemServiceTest {
 		Assertions.assertThat(result.getCartItemList().get(1).getQuantity()).isEqualTo(3); // 두 번째 아이템 개수 확인
 	}
 
+	@Test
+	@DisplayName("fail: 유효하지 않은 유저 역할 (예외 발생)")
+	void getCartItemList_fail_invalidUserRole() {
+		// given
+		Integer userId = 1;
+		UserRole userRole = UserRole.STREAMER; // CUSTOMER가 아닌 경우
+
+		// when, then
+		Assertions.assertThatThrownBy(() -> cartItemService.getCartItemList(userId, userRole))
+			.isInstanceOf(ForbiddenException.class);
+	}
 
 
 

--- a/src/test/java/excluz/excluz/domain/cartItem/service/CartItemServiceTest.java
+++ b/src/test/java/excluz/excluz/domain/cartItem/service/CartItemServiceTest.java
@@ -10,19 +10,20 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import excluz.excluz.common.entity.CartItem;
 import excluz.excluz.common.entity.Item;
 import excluz.excluz.common.entity.User;
 import excluz.excluz.common.exception.BadRequestException;
+import excluz.excluz.common.exception.ForbiddenException;
 import excluz.excluz.common.exception.NotFoundException;
 import excluz.excluz.domain.cartItem.dto.request.CreateCartItemRequestDto;
 import excluz.excluz.domain.cartItem.dto.request.UpdateCartItemQuantityRequestDto;
 import excluz.excluz.domain.cartItem.dto.response.CreateCartItemResponseDto;
 import excluz.excluz.domain.cartItem.repository.CartItemRepository;
 import excluz.excluz.domain.store.item.repository.ItemRepository;
+import excluz.excluz.domain.user.enums.UserRole;
 import excluz.excluz.domain.user.repository.UserRepository;
 
 @ExtendWith(MockitoExtension.class)
@@ -57,8 +58,9 @@ class CartItemServiceTest {
 			100,          // price: 100 (상품 가격)
 			100           // remainingQuantity: 100 (재고 개수)
 		);
-
 		Integer userId = 1;
+		UserRole userRole = UserRole.CUSTOMER;
+
 		CreateCartItemRequestDto requestDto = new CreateCartItemRequestDto(
 			1, // itemId: 1 (아이템 아이디)
 			99 // quantity: 99 (장바구니에 담는 물건 개수)
@@ -66,6 +68,8 @@ class CartItemServiceTest {
 
 		when(userRepository.findById(userId)).thenReturn(Optional.of(user));
 		when(itemRepository.findById(requestDto.getItemId())).thenReturn(Optional.of(item));
+		when(cartItemRepository.findByUserIdAndItemId(userId, requestDto.getItemId()))
+			.thenReturn(Optional.of(new CartItem(user, item, 0)));
 
 		CartItem cartItem = new CartItem(
 			user,
@@ -76,16 +80,18 @@ class CartItemServiceTest {
 		when(cartItemRepository.save(any(CartItem.class))).thenReturn(cartItem);
 
 		// when
-		CreateCartItemResponseDto result = cartItemService.addItemToCart(userId, requestDto);
+		CreateCartItemResponseDto result = cartItemService.addItemToCart(userId, userRole, requestDto);
 
 		// than
-		verify(cartItemRepository, times(1)).save(any(CartItem.class));  // save()가 1번만 실행되었는지 확인
+		verify(cartItemRepository, times(1)).save(any(CartItem.class)); // save()가 1번만 실행되었는지 확인
 		Assertions.assertThat(result).isNotNull(); // 반환값이 null이 아닌지 확인
-		Assertions.assertThat(result.getMessage()).isEqualTo("장바구니에 굿즈가 담겼습니다."); // 응답 메시지 동일하게 나오는지 확인
+		Assertions.assertThat(result.getQuantity()).isEqualTo(99); // 요청 수량이 맞는지 확인
+		Assertions.assertThat(result.getItemPrice()).isEqualTo(100); // 아이템 금액 맞는지 확인
+		Assertions.assertThat(result.getTotalItemPrice()).isEqualTo(9900); // 아이템 총액이 맞는지 확인
 	}
 
 	@Test
-	@DisplayName("success: 특정 아이템 재고와 동일한 수량 요청")
+	@DisplayName("success: 재고와 동일한 수량을 장바구니에 추가")
 	void addItemToCart_success_matchingStockQuantity_case_1() {
 		// given
 		User user = mock(User.class);
@@ -98,6 +104,8 @@ class CartItemServiceTest {
 		);
 
 		Integer userId = 1;
+		UserRole userRole = UserRole.CUSTOMER;
+
 		CreateCartItemRequestDto requestDto = new CreateCartItemRequestDto(
 			1,  // itemId: 1 (아이템 아이디)
 			100 // quantity: 100 (장바구니에 담는 물건 개수)
@@ -110,16 +118,18 @@ class CartItemServiceTest {
 		when(cartItemRepository.save(any(CartItem.class))).thenReturn(mock(CartItem.class));
 
 		// when
-		CreateCartItemResponseDto result = cartItemService.addItemToCart(userId, requestDto);
+		CreateCartItemResponseDto result = cartItemService.addItemToCart(userId, userRole, requestDto);
 
 		// then
 		verify(cartItemRepository, times(1)).save(any(CartItem.class));  // save()가 1번만 실행되었는지 확인
 		Assertions.assertThat(result).isNotNull(); // 반환값이 null이 아닌지 확인
-		Assertions.assertThat(result.getMessage()).isEqualTo("장바구니에 굿즈가 담겼습니다."); // 응답 메시지 동일하게 나오는지 확인
+		Assertions.assertThat(result.getQuantity()).isEqualTo(100); // 요청 수량이 맞는지 확인
+		Assertions.assertThat(result.getItemPrice()).isEqualTo(100); // 아이템 금액 맞는지 확인
+		Assertions.assertThat(result.getTotalItemPrice()).isEqualTo(10000); // 아이템 총액이 맞는지 확인
 	}
 
 	@Test
-	@DisplayName("success: 기 요청 개수 + 새로운 요청 개수 = 특정 아이템 재고 개수")
+	@DisplayName("success: 장바구니에 있는 개수 + 추가 요청 개수 = 재고")
 	void addItemToCart_success_matchingStockQuantity_case_2() {
 		// given
 		User user = mock(User.class);
@@ -132,6 +142,8 @@ class CartItemServiceTest {
 		);
 
 		Integer userId = 1;
+		UserRole userRole = UserRole.CUSTOMER;
+
 		CreateCartItemRequestDto requestDto = new CreateCartItemRequestDto(
 			1, // itemId: 1 (아이템 아이디)
 			50 // quantity: 50 (장바구니에 담는 물건 개수)
@@ -144,12 +156,14 @@ class CartItemServiceTest {
 		when(cartItemRepository.save(any(CartItem.class))).thenReturn(mock(CartItem.class));
 
 		// when
-		CreateCartItemResponseDto result = cartItemService.addItemToCart(userId, requestDto);
+		CreateCartItemResponseDto result = cartItemService.addItemToCart(userId, userRole, requestDto);
 
 		// then
-		verify(cartItemRepository, times(1)).save(any(CartItem.class));
-		Assertions.assertThat(result).isNotNull();
-		Assertions.assertThat(result.getMessage()).isEqualTo("장바구니에 굿즈가 담겼습니다.");
+		verify(cartItemRepository, times(1)).save(any(CartItem.class));  // save()가 1번만 실행되었는지 확인
+		Assertions.assertThat(result).isNotNull(); // 반환값이 null이 아닌지 확인
+		Assertions.assertThat(result.getQuantity()).isEqualTo(100); // 요청 수량이 맞는지 확인
+		Assertions.assertThat(result.getItemPrice()).isEqualTo(100); // 아이템 금액 맞는지 확인
+		Assertions.assertThat(result.getTotalItemPrice()).isEqualTo(10000); // 아이템 총액이 맞는지 확인
 	}
 
 	@Test
@@ -157,6 +171,7 @@ class CartItemServiceTest {
 	void addItemToCart_fail_userNotFound() {
 		// given
 		Integer userId = 1;
+		UserRole userRole = UserRole.CUSTOMER;
 		CreateCartItemRequestDto requestDto = new CreateCartItemRequestDto(
 			1, // itemId: 1 (아이템 아이디)
 			10 // quantity: 10 (장바구니에 담는 물건 개수)
@@ -165,7 +180,7 @@ class CartItemServiceTest {
 		when(userRepository.findById(userId)).thenReturn(Optional.empty()); // 유저가 없는 경우
 
 		// when, then
-		Assertions.assertThatThrownBy(() -> cartItemService.addItemToCart(userId, requestDto))
+		Assertions.assertThatThrownBy(() -> cartItemService.addItemToCart(userId, userRole, requestDto))
 			.isInstanceOf(NotFoundException.class);
 	}
 
@@ -174,6 +189,7 @@ class CartItemServiceTest {
 	void addItemToCart_fail_itemNotFound() {
 		// given
 		Integer userId = 1;
+		UserRole userRole = UserRole.CUSTOMER;
 		CreateCartItemRequestDto requestDto = new CreateCartItemRequestDto(
 			1, // itemId: 1 (아이템 아이디)
 			10 // quantity: 10 (장바구니에 담는 물건 개수)
@@ -183,7 +199,7 @@ class CartItemServiceTest {
 		when(itemRepository.findById(requestDto.getItemId())).thenReturn(Optional.empty()); // 아이템이 존재하지 않음
 
 		// when, then
-		Assertions.assertThatThrownBy(() -> cartItemService.addItemToCart(userId, requestDto))
+		Assertions.assertThatThrownBy(() -> cartItemService.addItemToCart(userId, userRole, requestDto))
 			.isInstanceOf(NotFoundException.class);
 	}
 
@@ -201,6 +217,8 @@ class CartItemServiceTest {
 		);
 
 		Integer userId = 1;
+		UserRole userRole = UserRole.CUSTOMER;
+
 		CreateCartItemRequestDto requestDto = new CreateCartItemRequestDto(
 			1,  // itemId: 1 (아이템 아이디)
 			101 // quantity: 101 (장바구니에 담는 물건 개수)
@@ -212,7 +230,7 @@ class CartItemServiceTest {
 			.thenReturn(Optional.of(new CartItem(user, item, 0))); // 기존 장바구니에 0개 있음
 
 		// when, then
-		Assertions.assertThatThrownBy(() -> cartItemService.addItemToCart(userId, requestDto))
+		Assertions.assertThatThrownBy(() -> cartItemService.addItemToCart(userId, userRole, requestDto))
 			.isInstanceOf(BadRequestException.class);
 	}
 
@@ -230,6 +248,8 @@ class CartItemServiceTest {
 		);
 
 		Integer userId = 1;
+		UserRole userRole = UserRole.CUSTOMER;
+
 		CreateCartItemRequestDto requestDto = new CreateCartItemRequestDto(
 			1, // itemId: 1 (아이템 아이디)
 			51 // quantity: 51 (장바구니에 담는 물건 개수)
@@ -241,8 +261,25 @@ class CartItemServiceTest {
 			.thenReturn(Optional.of(new CartItem(user, item, 50))); // 기존 장바구니에 50개 있음
 
 		// when, then
-		Assertions.assertThatThrownBy(() -> cartItemService.addItemToCart(userId, requestDto))
+		Assertions.assertThatThrownBy(() -> cartItemService.addItemToCart(userId, userRole, requestDto))
 			.isInstanceOf(BadRequestException.class);
+	}
+
+	@Test
+	@DisplayName("fail: 유효하지 않은 유저 역할 (예외 발생)")
+	void addItemToCart_fail_invalidUserRole() {
+		// given
+		Integer userId = 1;
+		UserRole userRole = UserRole.STREAMER; // CUSTOMER가 아닌 경우
+		CreateCartItemRequestDto requestDto = new CreateCartItemRequestDto(
+			1, // itemId: 1 (아이템 아이디)
+			1 // quantity: 1 (장바구니에 담는 물건 개수)
+		);
+		when(userRepository.findById(userId)).thenReturn(Optional.of(mock(User.class)));
+
+		// when, then
+		Assertions.assertThatThrownBy(() -> cartItemService.addItemToCart(userId, userRole, requestDto))
+			.isInstanceOf(ForbiddenException.class);
 	}
 
 	/*
@@ -262,6 +299,7 @@ class CartItemServiceTest {
 	@DisplayName("success: 요청 개수 < 재고")
 	void updateCartItemQuantity_success() {
 		// given
+		User user = mock(User.class);
 		Item item = new Item(
 			null,         // store: null (스토어 정보 없음)
 			"itemName",   // itemName: "itemName" (상품명)
@@ -270,29 +308,36 @@ class CartItemServiceTest {
 			11            // remainingQuantity: 11 (재고 개수)
 		);
 		CartItem cartItem = new CartItem(
-			null,  // user: null (사용자 정보 없음)
+			user,  // user: 위에서 생성한 user 객체
 			item,  // item: 위에서 생성한 Item 객체
 			10     // quantity: 10 (현재 장바구니에 담긴 수량)
 		);
 
-		Mockito.when(cartItemRepository.findByIdAndUserId(Mockito.any(), Mockito.any()))
+		Integer userId = 1;
+		UserRole userRole = UserRole.CUSTOMER;
+		Integer cartItemId = 1;
+
+		when(cartItemRepository.findByIdAndUserId(cartItemId, userId))
 			.thenReturn(Optional.of(cartItem));
 
-		UpdateCartItemQuantityRequestDto cartItemQuantityRequestDto = new UpdateCartItemQuantityRequestDto(1);
+		UpdateCartItemQuantityRequestDto requestDto = new UpdateCartItemQuantityRequestDto(1); // 개수 수정
 
 		// when, then
 		Assertions.assertThatCode(() -> cartItemService.updateCartItemQuantity(
-				null,   // user: null (사용자 정보 없음)
-				null,   // cartItem: null (장바구니 아이템 정보 없음)
-				cartItemQuantityRequestDto // 업데이트할 장바구니 아이템 정보
+				userId,
+				userRole,
+				cartItemId,
+				requestDto // 업데이트할 장바구니 아이템 정보
 			))
-			.doesNotThrowAnyException();
+			.doesNotThrowAnyException(); // 예외 발생하지 않아야 함
+		verify(cartItemRepository, times(1)).save(any(CartItem.class));  // save()가 1번만 실행되었는지 확인
 	}
 
 	@Test
 	@DisplayName("fail: 요청 개수 > 재고 (예외 발생)")
 	void updateCartItemQuantity_fail() {
 		// given
+		User user = mock(User.class);
 		Item item = new Item(
 			null,         // store: null (스토어 정보 없음)
 			"itemName",   // itemName: "itemName" (상품명)
@@ -301,21 +346,26 @@ class CartItemServiceTest {
 			10            // remainingQuantity: 10 (재고 개수)
 		);
 		CartItem cartItem = new CartItem(
-			null,  // user: null (사용자 정보 없음)
+			user,  // user: 위에서 생성한 user 객체
 			item,  // item: 위에서 생성한 Item 객체
 			10     // quantity: 10 (현재 장바구니에 담긴 수량)
 		);
 
-		Mockito.when(cartItemRepository.findByIdAndUserId(Mockito.any(), Mockito.any()))
+		Integer userId = 1;
+		UserRole userRole = UserRole.CUSTOMER;
+		Integer cartItemId = 1;
+
+		when(cartItemRepository.findByIdAndUserId(cartItemId, userId))
 			.thenReturn(Optional.of(cartItem));
 
-		UpdateCartItemQuantityRequestDto cartItemQuantityRequestDto = new UpdateCartItemQuantityRequestDto(100);
+		UpdateCartItemQuantityRequestDto requestDto = new UpdateCartItemQuantityRequestDto(100); // 100개로 개수 수정
 
 		// when, then
 		Assertions.assertThatThrownBy(() -> cartItemService.updateCartItemQuantity(
-				null,   // user: null (사용자 정보 없음)
-				null,   // cartItem: null (장바구니 아이템 정보 없음)
-				cartItemQuantityRequestDto // 업데이트할 장바구니 아이템 정보
+				userId,
+				userRole,
+				cartItemId,
+				requestDto // 업데이트할 장바구니 아이템 정보
 			))
 			.isInstanceOf(BadRequestException.class);
 	}

--- a/src/test/java/excluz/excluz/domain/cartItem/service/CartItemServiceTest.java
+++ b/src/test/java/excluz/excluz/domain/cartItem/service/CartItemServiceTest.java
@@ -2,6 +2,7 @@ package excluz.excluz.domain.cartItem.service;
 
 import static org.mockito.Mockito.*;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.assertj.core.api.Assertions;
@@ -22,6 +23,7 @@ import excluz.excluz.common.exception.ForbiddenException;
 import excluz.excluz.common.exception.NotFoundException;
 import excluz.excluz.domain.cartItem.dto.request.CreateCartItemRequestDto;
 import excluz.excluz.domain.cartItem.dto.request.UpdateCartItemQuantityRequestDto;
+import excluz.excluz.domain.cartItem.dto.response.CartItemListResponseDto;
 import excluz.excluz.domain.cartItem.dto.response.CreateCartItemResponseDto;
 import excluz.excluz.domain.cartItem.dto.response.GetCartItemResponseDto;
 import excluz.excluz.domain.cartItem.repository.CartItemRepository;
@@ -363,6 +365,62 @@ class CartItemServiceTest {
 	/*
 	 * getCartItemList
 	 */
+	@Test
+	@DisplayName("success: 장바구니 아이템 목록 조회")
+	void getCartItemList_success() {
+		// given
+		User user = mock(User.class);
+		Store store = mock(Store.class);
+
+		Item item1 = new Item(
+			store,         // store: 위에서 생성한 store 객체
+			"itemName",   // itemName: "itemName" (상품명)
+			"test",       // explanation: "test" (설명)
+			100,          // price: 100 (상품 가격)
+			10            // remainingQuantity: 10 (재고 개수)
+		);
+		Item item2 = new Item(
+			store,         // store: 위에서 생성한 store 객체
+			"itemName2",   // itemName: "itemName2" (상품명)
+			"test2",       // explanation: "test2" (설명)
+			200,          // price: 200 (상품 가격)
+			20            // remainingQuantity: 20 (재고 개수)
+		);
+
+		CartItem cartItem1 = new CartItem(
+			user,  // user: 위에서 생성한 user 객체
+			item1,  // item: 위에서 생성한 Item1 객체
+			2      // quantity: 2 (현재 장바구니에 담긴 수량)
+		);
+		CartItem cartItem2 = new CartItem(
+			user,  // user: 위에서 생성한 user 객체
+			item2,  // item: 위에서 생성한 Item2 객체
+			3      // quantity: 3 (현재 장바구니에 담긴 수량)
+		);
+
+		ReflectionTestUtils.setField(user, "id", 1);
+		ReflectionTestUtils.setField(cartItem1, "id", 1);
+		ReflectionTestUtils.setField(cartItem2, "id", 2);
+
+		UserRole userRole = UserRole.CUSTOMER;
+
+		when(cartItemRepository.findByUserId(user.getId()))
+			.thenReturn(List.of(cartItem1, cartItem2));
+
+		// when
+		CartItemListResponseDto result = cartItemService.getCartItemList(user.getId(), userRole);
+
+		// then
+		Assertions.assertThat(result).isNotNull(); // 결과가 null이 아닌지 확인
+		Assertions.assertThat(result.getCartItemList()).hasSize(2); // 장바구니에 2개 아이템 있는지 확인
+		Assertions.assertThat(result.getTotalPrice()).isEqualTo(800); // (100*2 + 200*3) = 800 확인
+
+		Assertions.assertThat(result.getCartItemList().get(0).getQuantity()).isEqualTo(2); // 첫 번째 아이템 개수 확인
+		Assertions.assertThat(result.getCartItemList().get(1).getQuantity()).isEqualTo(3); // 두 번째 아이템 개수 확인
+	}
+
+
+
 
 	/*
 	 * updateCartItemQuantity

--- a/src/test/java/excluz/excluz/domain/cartItem/service/CartItemServiceTest.java
+++ b/src/test/java/excluz/excluz/domain/cartItem/service/CartItemServiceTest.java
@@ -666,5 +666,16 @@ class CartItemServiceTest {
 			.isInstanceOf(NotFoundException.class); // NotFoundException 예외 발생
 	}
 
+	@Test
+	@DisplayName("fail: 유효하지 않은 유저 역할 (예외 발생)")
+	void removeCartItem_fail_invalidUserRole() {
+		// given
+		Integer userId = 1;
+		Integer cartItemId = 1;
+		UserRole userRole = UserRole.STREAMER; // 유효하지 않은 유저 역할 (CUSTOMER가 아님)
 
+		// when, then
+		Assertions.assertThatThrownBy(() -> cartItemService.removeCartItem(userId, userRole, cartItemId))
+			.isInstanceOf(ForbiddenException.class); // ForbiddenException 예외 발생
+	}
 }


### PR DESCRIPTION
## 목적
- 장바구니 서비스(CartItemService)의 CRUD 기능에 대한 단위 테스트 추가
  - 장바구니 아이템 추가 (성공 및 실패 케이스)
  - 장바구니 아이템 단건 조회 (성공 및 실패 케이스)
  - 장바구니 아이템 다건 조회 (성공 및 실패 케이스)
  - 장바구니 아이템 개수 수정 (성공 및 실패 케이스)
  - 장바구니 아이템 삭제 (성공 및 실패 케이스)
- 기존 테스트 메서드명을 팀 컨벤션에 맞게 **카멜 케이스**로 변경
- 장바구니 관련 테스트에서 **UserRole 검증 로직이 정상적으로 동작하는지 확인**하는 케이스 추가

## 변경점
- `CartItemServiceTest` 내 **CRUD 단위 테스트 추가**
- `CreateCartItemResponseDto`의 상세 필드 추가
- UserRole 기반 장바구니 접근 제한 로직 추가
- 팀 컨벤션에 맞춰 테스트 메서드명 **카멜 케이스**로 수정

