### PR TITLE
✅  test: UserServiceTest

### DIFF
--- a/src/main/java/excluz/excluz/common/entity/User.java
+++ b/src/main/java/excluz/excluz/common/entity/User.java
@@ -89,11 +89,9 @@ public class User extends BaseEntity{
 	public void updateUserProfile(
 			String nickName,
 			String phoneNumber,
-			String address,
-			String email ) {
+			String address) {
 		this.nickName = nickName;
 		this.phoneNumber = phoneNumber;
 		this.address = address;
-		this.email = email;
 	}
 }

--- a/src/main/java/excluz/excluz/common/entity/User.java
+++ b/src/main/java/excluz/excluz/common/entity/User.java
@@ -90,8 +90,8 @@ public class User extends BaseEntity{
 			String nickName,
 			String phoneNumber,
 			String address) {
-		this.nickName = nickName;
-		this.phoneNumber = phoneNumber;
-		this.address = address;
+		if(nickName != null) {this.nickName = nickName;}
+		if(phoneNumber != null) {this.phoneNumber = phoneNumber;}
+		if(address != null) {this.address = address;}
 	}
 }

--- a/src/main/java/excluz/excluz/domain/user/controller/UserController.java
+++ b/src/main/java/excluz/excluz/domain/user/controller/UserController.java
@@ -1,8 +1,8 @@
 package excluz.excluz.domain.user.controller;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.User;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -12,9 +12,8 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
 import excluz.excluz.auth.util.SecurityContextUtil;
-import excluz.excluz.domain.user.dto.UpdatePasswordRequestDto;
+import excluz.excluz.domain.user.dto.request.UpdatePasswordRequestDto;
 import excluz.excluz.domain.user.dto.request.UpdateMyProfileRequestDto;
 import excluz.excluz.domain.user.dto.request.UserLoginRequestDto;
 import excluz.excluz.domain.user.dto.request.UserSignupRequestDto;
@@ -25,7 +24,6 @@ import excluz.excluz.domain.user.dto.response.UpdatePasswordResponseDto;
 import excluz.excluz.domain.user.dto.response.UserLoginResponseDto;
 import excluz.excluz.domain.user.dto.response.UserProfileResponseDto;
 import excluz.excluz.domain.user.dto.response.UserSignupResponseDto;
-import excluz.excluz.domain.user.dto.response.UserWithdrawResponseDto;
 import excluz.excluz.domain.user.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -57,14 +55,15 @@ public class UserController {
 	}
 
 	@DeleteMapping("/soft")
-	public ResponseEntity<UserWithdrawResponseDto> userUnregisterAPI(
+	@PreAuthorize("hasRole('CUSTOMER')")
+	public ResponseEntity<Void> userUnregisterAPI(
 		@RequestBody UserWithdrawRequestDto userWithdrawRequest) {
 
 		Integer userId = SecurityContextUtil.getUserOrStreamerId();
 
-		UserWithdrawResponseDto userWithdrawResponseDto = userService.userWithdraw(userId, userWithdrawRequest);
+		userService.userWithdraw(userId, userWithdrawRequest);
 
-		return ResponseEntity.ok(userWithdrawResponseDto);
+		return new ResponseEntity<>(HttpStatus.OK);
 	}
 
 	// 마이페이지가 아닌 다른 유저의 정보 조회
@@ -89,12 +88,11 @@ public class UserController {
 
 	@PatchMapping("/profile")
 	public ResponseEntity<UpdateMyProfileResponseDto> userProfileUpdateAPI(
-		@AuthenticationPrincipal User user,
 		@RequestBody UpdateMyProfileRequestDto updateMyProfileRequest) {
 
 		Integer userId = SecurityContextUtil.getUserOrStreamerId();
 
-		UpdateMyProfileResponseDto updateMyProfileResponse = userService.userUpdateMyProfile(userId, updateMyProfileRequest);
+		UpdateMyProfileResponseDto updateMyProfileResponse = userService.updateMyProfile(userId, updateMyProfileRequest);
 
 		return ResponseEntity.ok(updateMyProfileResponse);
 	}
@@ -105,7 +103,7 @@ public class UserController {
 
 		Integer userId = SecurityContextUtil.getUserOrStreamerId();
 
-		UpdatePasswordResponseDto updatePasswordResponse = userService.userUpdatePassword(userId, updatePasswordRequest);
+		UpdatePasswordResponseDto updatePasswordResponse = userService.updatePassword(userId, updatePasswordRequest);
 
 		return ResponseEntity.ok(updatePasswordResponse);
 	}

--- a/src/main/java/excluz/excluz/domain/user/controller/UserController.java
+++ b/src/main/java/excluz/excluz/domain/user/controller/UserController.java
@@ -77,6 +77,7 @@ public class UserController {
 	}
 
 	@GetMapping("/profile")
+	@PreAuthorize("hasRole('CUSTOMER')")
 	public ResponseEntity<MyProfileResponseDto> myPageGetAPI() {
 
 		Integer userId = SecurityContextUtil.getUserOrStreamerId();
@@ -87,6 +88,7 @@ public class UserController {
 	}
 
 	@PatchMapping("/profile")
+	@PreAuthorize("hasRole('CUSTOMER')")
 	public ResponseEntity<UpdateMyProfileResponseDto> userProfileUpdateAPI(
 		@RequestBody UpdateMyProfileRequestDto updateMyProfileRequest) {
 
@@ -98,6 +100,7 @@ public class UserController {
 	}
 
 	@PutMapping("/password")
+	@PreAuthorize("hasRole('CUSTOMER')")
 	public ResponseEntity<UpdatePasswordResponseDto> userUpdatePasswordAPU(
 		@RequestBody UpdatePasswordRequestDto updatePasswordRequest) {
 

--- a/src/main/java/excluz/excluz/domain/user/dto/request/UpdateMyProfileRequestDto.java
+++ b/src/main/java/excluz/excluz/domain/user/dto/request/UpdateMyProfileRequestDto.java
@@ -9,7 +9,6 @@ public class UpdateMyProfileRequestDto {
 	private final String nickName;
 	private final String phoneNumber;
 	private final String address;
-	private final String email;
 	private final String password;
 
 	@Builder
@@ -17,12 +16,10 @@ public class UpdateMyProfileRequestDto {
 			String nickName,
 			String phoneNumber,
 			String address,
-			String email,
 			String password) {
 		this.nickName = nickName;
 		this.phoneNumber = phoneNumber;
 		this.address = address;
-		this.email = email;
 		this.password = password;
 	}
 }

--- a/src/main/java/excluz/excluz/domain/user/dto/request/UpdatePasswordRequestDto.java
+++ b/src/main/java/excluz/excluz/domain/user/dto/request/UpdatePasswordRequestDto.java
@@ -1,4 +1,4 @@
-package excluz.excluz.domain.user.dto;
+package excluz.excluz.domain.user.dto.request;
 
 import lombok.Getter;
 

--- a/src/main/java/excluz/excluz/domain/user/dto/response/UpdateMyProfileResponseDto.java
+++ b/src/main/java/excluz/excluz/domain/user/dto/response/UpdateMyProfileResponseDto.java
@@ -8,12 +8,16 @@ import lombok.Getter;
 @Getter
 public class UpdateMyProfileResponseDto {
 
-	private final String message;
+	private final String nickname;
+	private final String phoneNumber;
+	private final String address;
 	private final LocalDateTime updatedAt;
 
-	public UpdateMyProfileResponseDto(String message, User user) {
+	public UpdateMyProfileResponseDto(User user) {
 
-		this.message = message;
+		this.nickname = user.getNickName();
+		this.phoneNumber = user.getPhoneNumber();
+		this.address = user.getAddress();
 		this.updatedAt = user.getUpdatedAt();
 
 	}

--- a/src/main/java/excluz/excluz/domain/user/dto/response/UpdatePasswordResponseDto.java
+++ b/src/main/java/excluz/excluz/domain/user/dto/response/UpdatePasswordResponseDto.java
@@ -8,11 +8,9 @@ import lombok.Getter;
 @Getter
 public class UpdatePasswordResponseDto {
 
-	private final String message;
 	private final LocalDateTime updatedAt;
 
-	public UpdatePasswordResponseDto(String message, User user) {
-		this.message = message;
+	public UpdatePasswordResponseDto(User user) {
 		this.updatedAt = user.getUpdatedAt();
 	}
 }

--- a/src/main/java/excluz/excluz/domain/user/dto/response/UserLoginResponseDto.java
+++ b/src/main/java/excluz/excluz/domain/user/dto/response/UserLoginResponseDto.java
@@ -5,11 +5,9 @@ import lombok.Getter;
 @Getter
 public class UserLoginResponseDto {
 
-	private final String message;
 	private final String token;
 
-	public UserLoginResponseDto(String message, String token) {
-		this.message = message;
+	public UserLoginResponseDto(String token) {
 		this.token = token;
 	}
 }

--- a/src/main/java/excluz/excluz/domain/user/dto/response/UserSignupResponseDto.java
+++ b/src/main/java/excluz/excluz/domain/user/dto/response/UserSignupResponseDto.java
@@ -8,11 +8,19 @@ import lombok.Getter;
 @Getter
 public class UserSignupResponseDto {
 
-	private final String message;
+	private final String name;
+	private final String nickName;
+	private final String phoneNumber;
+	private final String address;
+	private final String email;
 	private final LocalDateTime createdAt;
 
-	public UserSignupResponseDto(String message, User user) {
-		this.message = message;
+	public UserSignupResponseDto(User user) {
+		this.name = user.getName();
+		this.nickName = user.getNickName();
+		this.phoneNumber = user.getPhoneNumber();
+		this.address = user.getAddress();
+		this.email = user.getEmail();
 		this.createdAt = user.getCreatedAt();
 	}
 }

--- a/src/main/java/excluz/excluz/domain/user/service/UserService.java
+++ b/src/main/java/excluz/excluz/domain/user/service/UserService.java
@@ -11,8 +11,8 @@ import excluz.excluz.common.entity.User;
 import excluz.excluz.common.exception.BadRequestException;
 import excluz.excluz.common.exception.NotFoundException;
 import excluz.excluz.common.exception.error.ErrorCode;
-import excluz.excluz.domain.user.dto.UpdatePasswordRequestDto;
 import excluz.excluz.domain.user.dto.request.UpdateMyProfileRequestDto;
+import excluz.excluz.domain.user.dto.request.UpdatePasswordRequestDto;
 import excluz.excluz.domain.user.dto.request.UserLoginRequestDto;
 import excluz.excluz.domain.user.dto.request.UserSignupRequestDto;
 import excluz.excluz.domain.user.dto.request.UserWithdrawRequestDto;
@@ -40,6 +40,8 @@ public class UserService {
 		// 가입된 유저의 이메일 여부를 확인
 		Optional<User> existingUser = userRepository.findByEmail(signupRequest.getEmail());
 
+		// Oauth 소셜 로그인을 진행했을때 로그인된 이메일과 소셜 로그인 연동을 처리한다. 소셜 로그인이 연동 되어있는 경우에만 메일 발송
+
 		// 이미 가입된 유저의 경우의 예외
 		if (existingUser.isPresent()) {
 			throw new BadRequestException(ErrorCode.EMAIL_ALREADY_EXISTS);
@@ -61,7 +63,7 @@ public class UserService {
 
 		userRepository.save(user);
 
-		return new UserSignupResponseDto("회원가입이 완료되었습니다.", user);
+		return new UserSignupResponseDto(user);
 	}
 
 	// 유저 로그인
@@ -78,13 +80,12 @@ public class UserService {
 		String token = jwtUtil.createToken(user.getEmail(), user.getId(), user.getUserRole());
 
 		// 로그인 완료 메세지 및 토큰값 발행
-		return new UserLoginResponseDto("로그인 되었습니다.", token);
+		return new UserLoginResponseDto(token);
 	}
 
 	// 회원탈퇴
 	@Transactional
-	public UserWithdrawResponseDto userWithdraw(
-		Integer userId, UserWithdrawRequestDto userWithdrawRequest) {
+	public void userWithdraw(Integer userId, UserWithdrawRequestDto userWithdrawRequest) {
 
 		// 유저 정보를 userId 로 조회
 		User user = userProfile(userId);
@@ -97,8 +98,6 @@ public class UserService {
 
 		// 유저의 isDeleted 의 상태가 true 가 됨
 		user.updateUserStatus(true);
-
-		return new UserWithdrawResponseDto("회원탈퇴가 완료되었습니다 저희 서비스를 이용해주셔서 감사합니다.");
 	}
 
 	// 유저 조회
@@ -126,7 +125,7 @@ public class UserService {
 
 	// 내정보 수정
 	@Transactional
-	public UpdateMyProfileResponseDto userUpdateMyProfile(Integer userId, UpdateMyProfileRequestDto updateMyProfileRequest) {
+	public UpdateMyProfileResponseDto updateMyProfile(Integer userId, UpdateMyProfileRequestDto updateMyProfileRequest) {
 
 		User user = userProfile(userId);
 
@@ -136,16 +135,15 @@ public class UserService {
 		user.updateUserProfile(
 			updateMyProfileRequest.getNickName(),
 			updateMyProfileRequest.getPhoneNumber(),
-			updateMyProfileRequest.getAddress(),
-			updateMyProfileRequest.getEmail()
+			updateMyProfileRequest.getAddress()
 			);
 
-		return new UpdateMyProfileResponseDto("회원 정보가 수정되었습니다.", user);
+		return new UpdateMyProfileResponseDto(user);
 	}
 
 	// 비밀번호 변경 로직
 	@Transactional
-	public UpdatePasswordResponseDto userUpdatePassword(Integer userId, UpdatePasswordRequestDto updatePasswordRequest) {
+	public UpdatePasswordResponseDto updatePassword(Integer userId, UpdatePasswordRequestDto updatePasswordRequest) {
 
 		User user = userProfile(userId);
 
@@ -155,30 +153,35 @@ public class UserService {
 		// 새로운 비밀번호와 재입력 비밀번호 검증 로직
 		matchPassword(updatePasswordRequest.getNewPassword(), updatePasswordRequest.getReEnterPassword());
 
+		// 새로운 비밀번호가 이전에 사용하던 비밀번호와 같을 경우 예외처리
+		if(passwordEncoder.matches(updatePasswordRequest.getNewPassword(), user.getPassword())) {
+			throw new BadRequestException(ErrorCode.INVALID_PASSWORD);
+		}
+
 		// 새로운 비밀번호 해싱처리
 		String bcryptPassword = passwordEncoder.encode(updatePasswordRequest.getNewPassword());
 
 		user.updatePassword(bcryptPassword);
 
-		return new UpdatePasswordResponseDto("비밀번호가 업데이트 되었습니다.", user);
+		return new UpdatePasswordResponseDto(user);
 	}
 
 	// 기타 메서드(비밀번호 검증)
-	private void validatePassword(String rawPassword, String encodedPassword) {
+	public void validatePassword(String rawPassword, String encodedPassword) {
 		if (!passwordEncoder.matches(rawPassword, encodedPassword)) {
 			throw new BadRequestException(ErrorCode.PASSWORD_MISMATCH);
 		}
 	}
 
 	// 기타 메서드(비밀번호와 재입력 비밀번호 검증)
-	private void matchPassword(String inputPassword, String reEnterPassword) {
+	public void matchPassword(String inputPassword, String reEnterPassword) {
 		if(!inputPassword.equals(reEnterPassword)) {
 			throw new BadRequestException(ErrorCode.PASSWORD_RE_ENTER_PASSWORD_MISMATCH);
 		}
 	}
 
 	// 기타 메서드 (회원 정보 조회)
-	private User userProfile(Integer userId) {
+	public User userProfile(Integer userId) {
 		return userRepository.findById(userId)
 			.orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND));
 	}

--- a/src/main/java/excluz/excluz/domain/user/service/UserService.java
+++ b/src/main/java/excluz/excluz/domain/user/service/UserService.java
@@ -22,7 +22,6 @@ import excluz.excluz.domain.user.dto.response.UpdatePasswordResponseDto;
 import excluz.excluz.domain.user.dto.response.UserLoginResponseDto;
 import excluz.excluz.domain.user.dto.response.UserProfileResponseDto;
 import excluz.excluz.domain.user.dto.response.UserSignupResponseDto;
-import excluz.excluz.domain.user.dto.response.UserWithdrawResponseDto;
 import excluz.excluz.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 

--- a/src/test/java/excluz/excluz/common/datas/SharedData.java
+++ b/src/test/java/excluz/excluz/common/datas/SharedData.java
@@ -8,6 +8,7 @@ import excluz.excluz.domain.store.item.dto.request.ItemUpdateRequestDto;
 import excluz.excluz.domain.store.item.dto.response.ItemResponseDto;
 import excluz.excluz.domain.streamer.dto.request.StreamerLoginRequestDto;
 import excluz.excluz.domain.streamer.dto.request.StreamerSignupRequestDto;
+import excluz.excluz.domain.user.dto.request.UserSignupRequestDto;
 
 /* 공유 데이터 */
 public class SharedData {
@@ -50,4 +51,20 @@ public class SharedData {
 	public final static ItemCreateRequestDto ITEM_CREATE_REQUEST_DTO = new ItemCreateRequestDto(ITEM_NAME1, EXPLANATION1, PRICE1, REMAINING_QUANTITY1);
 	public final static ItemUpdateRequestDto ITEM_UPDATE_REQUEST_DTO = new ItemUpdateRequestDto(ITEM_NAME2, EXPLANATION2, PRICE2, REMAINING_QUANTITY2);
 	public final static ItemResponseDto ITEM_RESPONSE_DTO = new ItemResponseDto(ITEM_NAME2, EXPLANATION2, PRICE2, REMAINING_QUANTITY2);
+
+	// User 데이터
+	public final static Integer USER_ID = 1;
+	public final static String USER_NAME1 = "홍길동";
+	public final static String USER_NICKNAME1 = "암행어사";
+	public final static String UPDATE_NICKNAME2 = "엄행어사";
+	public final static String USER_PHONE_NUMBER1 = "010-1234-1234";
+	public final static String USER_PHONE_NUMBER2 = "010-5678-1234";
+	public final static String USER_ADDRESS1 = "사랑시 평화동 정의로12";
+	public final static String USER_ADDRESS2 = "사랑시 고백구 행복4길 4-1";
+	public final static String USER_EMAIL1 = "test12@test.com";
+	public final static String USER_PASSWORD1 = "Qwer1234!!!!";
+	public final static String USER_REENTER_PASSWORD1 = "Qwer1234!!!!";
+	public final static String USER_PASSWORD2 = "Qwer1234!@@!";
+	public final static String USER_REENTER_PASSWORD2 = "Qwer1234!@@!";
+	public final static UserSignupRequestDto USER_SIGNUP_REQUEST_DTO = new UserSignupRequestDto(USER_NAME1, USER_NICKNAME1, USER_PHONE_NUMBER1, USER_ADDRESS1, USER_EMAIL1, USER_PASSWORD1, USER_REENTER_PASSWORD1);
 }

--- a/src/test/java/excluz/excluz/domain/user/service/UserServiceTest.java
+++ b/src/test/java/excluz/excluz/domain/user/service/UserServiceTest.java
@@ -1,0 +1,322 @@
+package excluz.excluz.domain.user.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+import java.util.Optional;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.util.ReflectionTestUtils;
+import excluz.excluz.auth.util.JwtUtil;
+import excluz.excluz.common.datas.SharedData;
+import excluz.excluz.common.entity.User;
+import excluz.excluz.common.exception.BadRequestException;
+import excluz.excluz.common.exception.NotFoundException;
+import excluz.excluz.domain.user.dto.request.UpdateMyProfileRequestDto;
+import excluz.excluz.domain.user.dto.request.UpdatePasswordRequestDto;
+import excluz.excluz.domain.user.dto.request.UserLoginRequestDto;
+import excluz.excluz.domain.user.dto.request.UserSignupRequestDto;
+import excluz.excluz.domain.user.dto.request.UserWithdrawRequestDto;
+import excluz.excluz.domain.user.dto.response.MyProfileResponseDto;
+import excluz.excluz.domain.user.dto.response.UpdateMyProfileResponseDto;
+import excluz.excluz.domain.user.dto.response.UserLoginResponseDto;
+import excluz.excluz.domain.user.dto.response.UserProfileResponseDto;
+import excluz.excluz.domain.user.dto.response.UserSignupResponseDto;
+import excluz.excluz.domain.user.repository.UserRepository;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+	// 가짜 객체
+	@Mock
+	private UserRepository userRepository;
+
+	@Mock
+	private PasswordEncoder passwordEncoder;
+
+	@Mock
+	private JwtUtil jwtUtil;
+
+	// 실제 객체
+	@InjectMocks
+	private UserService userService;
+
+	@Test
+	@DisplayName("회원 가입 - 성공 케이스")
+	public void userSignup() {
+		// give
+		UserSignupRequestDto signupRequest = SharedData.USER_SIGNUP_REQUEST_DTO;
+
+		// 실제로 동작할건 서비스 만 작동 시킬것이기 때문에 가짜 데이터를 넣어줌
+		when(userRepository.findByEmail(signupRequest.getEmail())).thenReturn(Optional.empty());
+		when(passwordEncoder.encode(signupRequest.getPassword())).thenReturn("&@a2djksladsaksllasrwpookl");
+
+		// when
+		UserSignupResponseDto userSignupResponse = userService.userSignup(signupRequest);
+
+		// then
+		assertEquals(signupRequest.getName(), userSignupResponse.getName());
+		assertEquals(signupRequest.getNickName(), userSignupResponse.getNickName());
+		assertEquals(signupRequest.getPhoneNumber(), userSignupResponse.getPhoneNumber());
+		assertEquals(signupRequest.getAddress(), userSignupResponse.getAddress());
+		assertEquals(signupRequest.getEmail(), userSignupResponse.getEmail());
+
+		// 실제로 코드가 실행됐는지 확인하는 로직 (PasswordEncoder)
+		verify(userRepository).findByEmail(signupRequest.getEmail());
+		verify(passwordEncoder).encode(signupRequest.getPassword());
+	}
+
+	@Test
+	@DisplayName("회원 가입 - 실패 케이스(이미 가입된 회원)")
+	public void userSignup_BadRequestException() {
+		// give
+		UserSignupRequestDto signupRequest = SharedData.USER_SIGNUP_REQUEST_DTO;
+		User user = mock(User.class);
+
+		when(userRepository.findByEmail(signupRequest.getEmail())).thenReturn(Optional.of(user));
+
+		// when, then
+		Assertions.assertThrows(BadRequestException.class, () -> {
+			userService.userSignup(signupRequest);
+		});
+	}
+
+	@Test
+	@DisplayName("로그인 - 성공 케이스")
+	public void userLogin() {
+		//give
+		UserLoginRequestDto loginRequest = new UserLoginRequestDto(
+			SharedData.USER_EMAIL1, SharedData.USER_PASSWORD1);
+
+		User user = User.builder()
+			.email(SharedData.USER_EMAIL1)
+				.build();
+
+		String token = "token";
+
+		// when
+		when(userRepository.findByEmail(loginRequest.getEmail())).thenReturn(Optional.of(user));
+		when(passwordEncoder.matches(loginRequest.getPassword(), user.getPassword())).thenReturn(true);
+		when(jwtUtil.createToken(user.getEmail(), user.getId(), user.getUserRole())).thenReturn(token);
+
+		UserLoginResponseDto userLoginResponse = userService.userLogin(loginRequest);
+
+		// dto의 반환 값이 null이 아닌지 검증 하는 로직이 필요
+		assertNotNull(userLoginResponse);
+
+		// 토큰값이 null 인지 혹은 empty String 인지 검증 필요
+		assertNotNull(userLoginResponse.getToken());
+		assertFalse(userLoginResponse.getToken().isEmpty());
+		assertEquals(userLoginResponse.getToken(), token);
+
+		// then
+		verify(userRepository).findByEmail(loginRequest.getEmail());
+		verify(passwordEncoder).matches(loginRequest.getPassword(), user.getPassword());
+		verify(jwtUtil).createToken(user.getEmail(), user.getId(), user.getUserRole());
+	}
+
+	@Test
+	@DisplayName("로그인 - 실패 케이스")
+	public void userLoginFailed() {
+		// give
+		UserLoginRequestDto LoginRequest = new UserLoginRequestDto(SharedData.USER_EMAIL1, SharedData.USER_PASSWORD1);
+
+		when(userRepository.findByEmail(LoginRequest.getEmail())).thenReturn(Optional.empty());
+
+		// when
+		Assertions.assertThrows(NotFoundException.class, () -> {
+			userService.userLogin(LoginRequest);
+		});
+	}
+
+	@Test
+	@DisplayName("회원탈퇴 - 성공 케이스")
+	public void userWithdraw() {
+		// give
+		UserWithdrawRequestDto withdrawRequest = new UserWithdrawRequestDto(SharedData.USER_PASSWORD1, SharedData.USER_REENTER_PASSWORD1);
+
+		User user = User.builder()
+				.build();
+
+		// user Entity의 생성자에 userId값이 존재하지 않으므로 id값을 강제로 설정해 줌
+		ReflectionTestUtils.setField(user, "id", SharedData.USER_ID);
+
+		when(userRepository.findById(anyInt())).thenReturn(Optional.of(user));
+		when(passwordEncoder.matches(withdrawRequest.getPassword(), user.getPassword())).thenReturn(true);
+
+		// when
+		userService.userWithdraw(user.getId(), withdrawRequest);
+
+		//then
+		assertThat(user.getIsDeleted()).isEqualTo(true);
+
+		verify(userRepository).findById(user.getId());
+		verify(passwordEncoder).matches(withdrawRequest.getPassword(), user.getPassword());
+	}
+
+	@Test
+	@DisplayName("회원조회 - 성공 케이스")
+	public void userGetProfile() {
+		//give
+		User user = User.builder()
+			.email(SharedData.USER_EMAIL1)
+			.nickName(SharedData.USER_NICKNAME1)
+			.build();
+
+		ReflectionTestUtils.setField(user, "id", SharedData.USER_ID);
+		when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
+
+		//when
+		UserProfileResponseDto userProfileResponse = userService.userGetProfile(user.getId());
+
+		//then
+		assertEquals(user.getNickName(), userProfileResponse.getNickName());
+		assertEquals(user.getEmail(), userProfileResponse.getEmail());
+
+		verify(userRepository).findById(user.getId());
+	}
+
+	@Test
+	@DisplayName("회원조회 - 실패 케이스")
+	public void userGetProfile_NotFoundException() {
+		// give
+		User user = User.builder()
+			.build();
+
+		ReflectionTestUtils.setField(user, "id", SharedData.USER_ID);
+		ReflectionTestUtils.setField(user, "isDeleted", true);
+		when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
+
+		// then
+		Assertions.assertThrows(NotFoundException.class, () ->
+			userService.userGetProfile(user.getId()));
+	}
+
+	@Test
+	@DisplayName("마이페이지 - 성공 케이스")
+	public void userGetMyProfile() {
+		// give
+		User user = User.builder()
+			.name(SharedData.USER_NAME1)
+			.nickName(SharedData.USER_NICKNAME1)
+			.email(SharedData.USER_EMAIL1)
+			.phoneNumber(SharedData.USER_PHONE_NUMBER1)
+			.address(SharedData.ADDRESS1)
+			.build();
+
+		ReflectionTestUtils.setField(user, "id", SharedData.USER_ID);
+		when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
+
+		// when
+		MyProfileResponseDto myProfileResponse = userService.userGetMyProfile(user.getId());
+
+		// then
+		assertEquals(user.getName(), myProfileResponse.getName());
+		assertEquals(user.getNickName(), myProfileResponse.getNickName());
+		assertEquals(user.getEmail(), myProfileResponse.getEmail());
+		assertEquals(user.getPhoneNumber(), myProfileResponse.getPhoneNumber());
+		assertEquals(user.getAddress(), myProfileResponse.getAddress());
+
+		verify(userRepository).findById(user.getId());
+	}
+
+	@Test
+	@DisplayName("내정보 수정 - 성공 케이스")
+	public void UpdateMyProfile() {
+		// give
+		UpdateMyProfileRequestDto updateMyProfileRequest = new UpdateMyProfileRequestDto(
+			SharedData.UPDATE_NICKNAME2, SharedData.USER_PHONE_NUMBER2, SharedData.USER_ADDRESS2, SharedData.USER_PASSWORD1);
+
+		User user = User.builder()
+			.nickName(SharedData.USER_NICKNAME1)
+			.phoneNumber(SharedData.USER_PHONE_NUMBER1)
+			.address(SharedData.ADDRESS1)
+			.build();
+
+		ReflectionTestUtils.setField(user, "id", SharedData.USER_ID);
+		when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
+		when(passwordEncoder.matches(updateMyProfileRequest.getPassword(), user.getPassword())).thenReturn(true);
+
+		// when
+		UpdateMyProfileResponseDto updateMyProfileResponse = userService.updateMyProfile(user.getId(), updateMyProfileRequest);
+
+		assertEquals(user.getNickName(), updateMyProfileResponse.getNickname());
+		assertEquals(user.getPhoneNumber(), updateMyProfileResponse.getPhoneNumber());
+		assertEquals(user.getAddress(), updateMyProfileResponse.getAddress());
+
+		verify(userRepository).findById(user.getId());
+	}
+
+	@Test
+	@DisplayName("내정보 수정 - 실패 케이스")
+	public void updateMyProfile_BadRequestException() {
+		UpdateMyProfileRequestDto updateMyProfileRequestDto = new UpdateMyProfileRequestDto(
+			SharedData.UPDATE_NICKNAME2, SharedData.USER_PHONE_NUMBER2, SharedData.USER_ADDRESS2, SharedData.USER_PASSWORD2);
+
+		User user = User.builder()
+			.build();
+
+		ReflectionTestUtils.setField(user, "id", SharedData.USER_ID);
+		when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
+
+		Assertions.assertThrows(BadRequestException.class, () ->
+			userService.updateMyProfile(user.getId(), updateMyProfileRequestDto));
+	}
+
+	// 5분기록 보드 작성할 것
+	@Test
+	@DisplayName("비밀번호 변경 - 성공 케이스")
+	public void updatePassword() {
+		//give
+		UpdatePasswordRequestDto updatePasswordRequest = new UpdatePasswordRequestDto(
+			SharedData.USER_PASSWORD1, SharedData.USER_PASSWORD2, SharedData.USER_REENTER_PASSWORD2);
+
+		User user = User.builder()
+			.build();
+
+		ReflectionTestUtils.setField(user, "id", SharedData.USER_ID);
+		ReflectionTestUtils.setField(user, "password", SharedData.USER_PASSWORD1);
+		when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
+		// System.out.println("유저 비밀번호: " + user.getPassword());
+		when(passwordEncoder.matches(updatePasswordRequest.getOldPassword(), user.getPassword())).thenReturn(true);
+		when(passwordEncoder.matches(updatePasswordRequest.getNewPassword(), user.getPassword())).thenReturn(false);
+		when(passwordEncoder.encode(updatePasswordRequest.getNewPassword())).thenReturn(updatePasswordRequest.getNewPassword());
+
+		// when
+		userService.updatePassword(user.getId(), updatePasswordRequest);
+
+		//then
+		assertEquals(updatePasswordRequest.getNewPassword(), user.getPassword());
+		// System.out.println("유저 비밀번호: " + user.getPassword());
+
+		verify(userRepository).findById(user.getId());
+		verify(passwordEncoder).matches(updatePasswordRequest.getOldPassword(), SharedData.USER_PASSWORD1);
+		verify(passwordEncoder).matches(updatePasswordRequest.getNewPassword(), SharedData.USER_PASSWORD1);
+	}
+
+	@Test
+	@DisplayName("비밀번호 변경 - 실패 케이스")
+	public void updatePassword_BadRequestException() {
+		// give
+		UpdatePasswordRequestDto updatePasswordRequest = new UpdatePasswordRequestDto(
+			SharedData.USER_PASSWORD1, SharedData.USER_PASSWORD1, SharedData.USER_PASSWORD1
+		);
+
+		User user = User.builder()
+			.build();
+
+		ReflectionTestUtils.setField(user, "id", SharedData.USER_ID);
+		ReflectionTestUtils.setField(user, "password", SharedData.USER_PASSWORD1);
+		when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
+		when(passwordEncoder.matches(updatePasswordRequest.getNewPassword(), user.getPassword())).thenReturn(true);
+
+		Assertions.assertThrows(BadRequestException.class, () ->
+			userService.updatePassword(user.getId(), updatePasswordRequest));
+	}
+}


### PR DESCRIPTION
## 목적
- 유저 서비스의 CRUD 기능 단위 테스트 추가
1. 회원 가입 기능(성공, 실패 케이스 추가)
2. 로그인 기능(성공, 실패 케이스 추가)
3. 회원탈퇴 기능(성공, 실패 케이스 추가)
4. 회원조회 기능(성공, 실패 케이스 추가)
5. 마이페이지 조회 기능(성공, 실패 케이스 추가)
6. 내정보 수정 기능(성공, 실패 케이스 추가)
7. 비밀번호 변경 기능(성공, 실패 케이스 추가)

## 변경점
1. ShareData에 userService를 위한 임시 테스트용 정보 추가
2. ResponseDto에 메세지가 반환되는 부분 삭제 및 데이터를 반환할 수 있게 수정
3. 변경된 ResponseDto에 맞춰 서비스 로직 수정
4. 비밀번호 변경 기능에 현재 비밀번호와 새로운 비밀번호가 일치하면 예외를 던지는 로직을 추가
5. dto패키지 외부에 있던 updateMyPageRequestDto를 request패키지로 이동
