### PR TITLE
:white_check_mark:test:Set All Event test and Complete Event logic

### DIFF
--- a/src/main/java/excluz/excluz/common/entity/Event.java
+++ b/src/main/java/excluz/excluz/common/entity/Event.java
@@ -51,6 +51,9 @@ public class Event extends BaseEntity  {
     @Column(name = "is_deleted",  nullable = false)
     private Boolean isDeleted;
 
+//    //    todo: 낙관적 락 테스트
+//    @Version
+//    private Integer version;
 
     // 생성자: 매개변수 4개 이상이므로 @Builder 패턴 사용
     @Builder

--- a/src/main/java/excluz/excluz/domain/event/event/enums/ParticipantCondition.java
+++ b/src/main/java/excluz/excluz/domain/event/event/enums/ParticipantCondition.java
@@ -1,7 +1,7 @@
 package excluz.excluz.domain.event.event.enums;
 
 public enum ParticipantCondition {
-    ALL_USERS,           // 로그인 여부 상관 없음
-    REGISTERED_USERS,    // 로그인한 회원만
-    GUEST_USERS          // 비회원만
+    ALL_USERS           // 로그인 여부 상관 없음
+//    REGISTERED_USERS,    // 로그인한 회원만
+//    GUEST_USERS          // 비회원만
 }

--- a/src/main/java/excluz/excluz/domain/event/event/repository/EventRepository.java
+++ b/src/main/java/excluz/excluz/domain/event/event/repository/EventRepository.java
@@ -11,7 +11,10 @@ import java.util.Optional;
 
 public interface EventRepository extends JpaRepository<Event, Integer> {
 
+//    todo: 낙관적/비관적 락 테스트
     @Lock(LockModeType.PESSIMISTIC_WRITE)
+//    @Lock(LockModeType.PESSIMISTIC_READ)
+//    @Lock(LockModeType.OPTIMISTIC)
     @Query("SELECT e FROM Event e WHERE e.generatedCode = :code")
     Optional<Event> findByGeneratedCode(@Param("code") String generatedCode);
 }

--- a/src/main/java/excluz/excluz/domain/event/event/service/EventService.java
+++ b/src/main/java/excluz/excluz/domain/event/event/service/EventService.java
@@ -25,10 +25,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -52,7 +49,7 @@ public class EventService {
                 .orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND));
 
         if (!streamer.getId().equals(streamerId)){
-            throw new UnauthorizedException(ErrorCode.UNAUTHORIZED_USER);
+            throw new UnauthorizedException(ErrorCode.STORE_NOT_MATCH);
         }
 
         if (eventRequestDto.getEndDatetime().isBefore(LocalDateTime.now())) {
@@ -126,7 +123,7 @@ public class EventService {
         Streamer streamer = streamerRepository.findById(streamerId)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND));
 
-        if (!streamer.getId().equals(streamerId)){
+        if (!event.getStore().getStreamer().getId().equals(streamer.getId())) {
             throw new UnauthorizedException(ErrorCode.STORE_NOT_MATCH);
         }
 
@@ -150,6 +147,7 @@ public class EventService {
     }
 
     // 이벤트 마감 메서드 추가
+    @Transactional
     public EventClosingResponseDto closeEvent(Integer streamerId, Integer eventId) {
         Event event = eventRepository.findById(eventId)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.EVENT_NOT_FOUND));
@@ -157,7 +155,7 @@ public class EventService {
         Streamer streamer = streamerRepository.findById(streamerId)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND));
 
-        if (!streamer.getId().equals(streamerId)){
+        if (!event.getStore().getStreamer().getId().equals(streamer.getId())) {
             throw new UnauthorizedException(ErrorCode.STORE_NOT_MATCH);
         }
 
@@ -171,17 +169,16 @@ public class EventService {
 
         // 이벤트 응모자 조회
         List<EventApplicant> applicantList = eventApplicantRepository.findByEvent(event);
-//        if (applicantList.isEmpty()) {
-//            throw new IllegalStateException("해당 이벤트에 응모자가 없습니다.");
-//        }
 
-        // 당첨자 선정 로직
+        // 당첨자 수
         int numberOfWinners = event.getNumberOfWinners();
+        // 실제 응모자 수
+        int actualApplicants = applicantList.size();
         if (event.getSelectionMethod() == SelectionMethod.RANDOM_DRAW) {
-            // 무작위 추첨
+            // 무작위 섞기
             Collections.shuffle(applicantList);
-            List<EventApplicant> winners = applicantList.subList(0, Math.min(numberOfWinners, applicantList.size()));
-
+            // 후보 리스트 중 최대 numberOfWinners명만 WINNER로
+            List<EventApplicant> winners = applicantList.subList(0, Math.min(numberOfWinners, actualApplicants));
             for (EventApplicant applicant : applicantList) {
                 if (winners.contains(applicant)) {
                     applicant.updateApplicantStatus(ApplicantStatus.WINNER);
@@ -189,25 +186,39 @@ public class EventService {
                     applicant.updateApplicantStatus(ApplicantStatus.LOSER);
                 }
             }
-        } else if (event.getSelectionMethod() == SelectionMethod.FIRST_COME_FIRST_SERVED) {
-//      응모시에 이미 WINNER/LOSER 구분 완료
-        } else {
+        }
+        else if (event.getSelectionMethod() == SelectionMethod.FIRST_COME_FIRST_SERVED) {
+            // 선착순은 이미 응모 로직에서 WINNER/LOSER 설정이 되었을 것으로 가정
+        }
+        else {
             throw new BadRequestException(ErrorCode.EVENT_METHOD_NOT_SUPPORTED);
         }
+
+        if (actualApplicants < numberOfWinners) {
+            int leftover = numberOfWinners - actualApplicants; // 미달 인원 수
+            List<EventItem> eventItems = eventItemRepository.findByEvent(event);
+            for (EventItem eventItem : eventItems) {
+                Item item = eventItem.getItem();
+                int returnQuantity = leftover * eventItem.getQuantity();
+                item.addRemainingQuantity(returnQuantity);
+                // 변경사항 저장 (영속성 컨텍스트 때문에 saveAll 대신 최종적으로 flush 되면 반영됨)
+                itemRepository.save(item);
+            }
+        }
+
 
         event.completeEvent();
 
         eventRepository.save(event);
         eventApplicantRepository.saveAll(applicantList);
 
-        List<EventItem> eventItems = eventItemRepository.findByEvent(event);
+        List<EventItem> eventItemList = eventItemRepository.findByEvent(event);
 
-        return EventClosingResponseDto.from(event, eventItems, applicantList);
+        return EventClosingResponseDto.from(event, eventItemList, applicantList);
     }
 
     private String generateUniqueCode() {
-        // todo: 고유 코드 생성 로직 구현 (예제용 코드)
-        return "UNIQUE_CODE" + eventRepository.count();
+        return "EVENT_" + UUID.randomUUID().toString().substring(0, 8).toUpperCase();
     }
 
 

--- a/src/main/java/excluz/excluz/domain/event/eventApplicant/repository/EventApplicantRepository.java
+++ b/src/main/java/excluz/excluz/domain/event/eventApplicant/repository/EventApplicantRepository.java
@@ -3,7 +3,11 @@ package excluz.excluz.domain.event.eventApplicant.repository;
 import excluz.excluz.common.entity.EventApplicant;
 import excluz.excluz.common.entity.Event;
 import excluz.excluz.domain.event.eventApplicant.enums.ApplicantStatus;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -13,7 +17,11 @@ public interface EventApplicantRepository extends JpaRepository<EventApplicant, 
 
     List<EventApplicant> findByEvent(Event event);
 
+//    @Lock(LockModeType.PESSIMISTIC_READ)
+//    @Query("SELECT COUNT(e) FROM EventApplicant e WHERE e.event = :event AND e.applicantStatus = :status")
+//    int countByEventAndApplicantStatus(@Param("event") Event event, @Param("status") ApplicantStatus status);
     int countByEventAndApplicantStatus(Event event, ApplicantStatus status);
+
 
     Boolean existsByEventAndEmail(Event event, String email);
 }

--- a/src/main/java/excluz/excluz/domain/event/eventApplicant/service/EventApplicantService.java
+++ b/src/main/java/excluz/excluz/domain/event/eventApplicant/service/EventApplicantService.java
@@ -15,9 +15,11 @@ import excluz.excluz.domain.event.eventApplicant.repository.EventApplicantReposi
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+
 
 @Service
 @Slf4j
@@ -27,7 +29,7 @@ public class EventApplicantService {
     private final EventApplicantRepository eventApplicantRepository;
     private final EventRepository eventRepository;
 
-    @Transactional // todo: 락 테스트
+    @Transactional(propagation=Propagation.REQUIRED) // todo: 락 테스트
     public EventApplicantResponseDto applyForEvent(String code, EventApplicantRequestDto requestDto) {
         Event event = eventRepository.findByGeneratedCode(code)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.EVENT_NOT_FOUND));
@@ -61,6 +63,8 @@ public class EventApplicantService {
                 .build();
 
         if (event.getSelectionMethod() == SelectionMethod.FIRST_COME_FIRST_SERVED) {
+            // todo: 이 단에서만 락이 걸려야 함
+            // 선착순이 아니어도 락이 걸리는 문제....
             int numberOfCurrentWinners = eventApplicantRepository.countByEventAndApplicantStatus(event, ApplicantStatus.WINNER);
             if (numberOfCurrentWinners < event.getNumberOfWinners()) {
                 eventApplicant.updateApplicantStatus(ApplicantStatus.WINNER);

--- a/src/test/java/excluz/excluz/domain/event/service/EventConcurrentFirstComeTest.java
+++ b/src/test/java/excluz/excluz/domain/event/service/EventConcurrentFirstComeTest.java
@@ -6,6 +6,7 @@ import excluz.excluz.domain.event.event.dto.EventResponseDto;
 import excluz.excluz.domain.event.event.enums.SelectionMethod;
 import excluz.excluz.domain.event.event.repository.EventRepository;
 import excluz.excluz.domain.event.event.service.EventService;
+import excluz.excluz.domain.event.eventApplicant.dto.EventApplicantRequestDto;
 import excluz.excluz.domain.event.eventApplicant.repository.EventApplicantRepository;
 import excluz.excluz.domain.event.eventApplicant.service.EventApplicantService;
 import excluz.excluz.domain.event.eventItem.dto.EventItemRequestDto;
@@ -116,7 +117,7 @@ public class EventConcurrentFirstComeTest {
     @Test
     public void testConcurrentApplicants_FirstComeFirstServed() throws Exception {
         // 동시성 테스트를 위한 스레드 풀과 CountDownLatch 준비
-        int numberOfThreads = 10; // 동시에 n명의 응모 시도
+        int numberOfThreads = 100; // 동시에 n명의 응모 시도
         ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
         CountDownLatch startLatch = new CountDownLatch(1); // 모든 스레드를 동시에 시작
         CountDownLatch finishLatch = new CountDownLatch(numberOfThreads);
@@ -135,8 +136,7 @@ public class EventConcurrentFirstComeTest {
                     // 응모 요청 (EventApplicantService.applyForEvent)
                     eventApplicantService.applyForEvent(
                             event.getGeneratedCode(),
-                            // 간단한 DTO 생성 (빌더 사용)
-                            excluz.excluz.domain.event.eventApplicant.dto.EventApplicantRequestDto.builder()
+                            EventApplicantRequestDto.builder()
                                     .email(email)
                                     .applicantName("사용자" + uniqueApplicantCode)
                                     .applicantPassword("password" + uniqueApplicantCode)
@@ -152,15 +152,13 @@ public class EventConcurrentFirstComeTest {
             });
         }
 
-        // 모든 스레드 시작
+        // 모든 스레드 시작 + 완료될 때까지 기다림
         startLatch.countDown();
-        // 모든 스레드 완료될 때까지 기다림
         finishLatch.await();
         executorService.shutdown();
 
-        // 모든 응모 처리 후, 이벤트 마감 로직 실행 (선착순 기준으로 당첨자 판별)
-        // 동시성 상황에서 저장된 응모는 createdAt 값 순으로 정렬됨.
-        var closingResponse = eventService.closeEvent(streamer.getId(), event.getId());
+        // 응모 다 처리 하고 이벤트 마감 로직 실행
+        eventService.closeEvent(streamer.getId(), event.getId());
 
         // 당첨자 수가 NUMBER_OF_WINNERS로 제한되었는지 확인
         List<EventApplicant> allApplicants = eventApplicantRepository.findByEvent(event);

--- a/src/test/java/excluz/excluz/domain/event/service/EventServiceTest.java
+++ b/src/test/java/excluz/excluz/domain/event/service/EventServiceTest.java
@@ -1,236 +1,961 @@
-// package excluz.excluz;
-
-// import excluz.excluz.common.entity.Event;
-// import excluz.excluz.common.entity.Item;
-// import excluz.excluz.common.entity.Store;
-// import excluz.excluz.common.entity.Streamer;
-// import excluz.excluz.domain.event.event.dto.EventRequestDto;
-// import excluz.excluz.domain.event.event.dto.EventResponseDto;
-// import excluz.excluz.domain.event.event.enums.ParticipantCondition;
-// import excluz.excluz.domain.event.event.enums.SelectionMethod;
-// import excluz.excluz.domain.event.event.repository.EventRepository;
-// import excluz.excluz.domain.event.event.service.EventService;
-// import excluz.excluz.domain.event.eventItem.dto.EventItemRequestDto;
-// import excluz.excluz.domain.event.eventItem.repository.EventItemRepository;
-// import excluz.excluz.domain.store.item.repository.ItemRepository;
-// import excluz.excluz.domain.store.store.repository.StoreRepository;
-// import org.junit.jupiter.api.BeforeEach;
-// import org.junit.jupiter.api.Test;
-// import org.junit.jupiter.api.extension.ExtendWith;
-// import org.mockito.InjectMocks;
-// import org.mockito.Mock;
-// import org.mockito.MockitoAnnotations;
-// import org.mockito.junit.jupiter.MockitoExtension;
-
-// import java.time.LocalDateTime;
-// import java.util.Collections;
-// import java.util.Optional;
-
-// import static org.mockito.Mockito.*;
-// import static org.junit.jupiter.api.Assertions.*;
-
-// @ExtendWith(MockitoExtension.class)
-// class EventServiceTest {
-
-//     @InjectMocks
-//     private EventService eventService;
-
-//     @Mock
-//     private StoreRepository storeRepository;
-
-//     @Mock
-//     private EventRepository eventRepository;
-
-//     @Mock
-//     private EventItemRepository eventItemRepository;
-
-//     @Mock
-//     private ItemRepository itemRepository;
-
-//     private Store store;
-//     private Item item;
-//     private Event event;
-
-//     @BeforeEach
-//     void setUp() {
-//         // Store 객체 생성
-//         store = Store.builder()
-//                 .streamer(new Streamer())
-//                 .address("Sample Address")
-//                 .storeName("Sample Store")
-//                 .registrationNumber("123-45-6789")
-//                 .build();
-//         store.setId(2);
+package excluz.excluz.domain.event.service;
 
 
-//         // Item 객체 생성
-//         item = new Item();
-//         item.setId(1);
-//         item.setItemName("Sample Item");
+import excluz.excluz.common.entity.*;
+import excluz.excluz.common.exception.BadRequestException;
+import excluz.excluz.common.exception.NotFoundException;
+import excluz.excluz.common.exception.UnauthorizedException;
+import excluz.excluz.common.exception.error.ErrorCode;
+import excluz.excluz.domain.event.event.dto.EventClosingResponseDto;
+import excluz.excluz.domain.event.event.dto.EventRequestDto;
+import excluz.excluz.domain.event.event.dto.EventResponseDto;
+import excluz.excluz.domain.event.event.enums.ParticipantCondition;
+import excluz.excluz.domain.event.event.enums.SelectionMethod;
+import excluz.excluz.domain.event.event.repository.EventRepository;
+import excluz.excluz.domain.event.event.service.EventService;
+import excluz.excluz.domain.event.eventApplicant.dto.EventApplicantRequestDto;
+import excluz.excluz.domain.event.eventApplicant.dto.EventApplicantResponseDto;
+import excluz.excluz.domain.event.eventApplicant.enums.ApplicantStatus;
+import excluz.excluz.domain.event.eventApplicant.repository.EventApplicantRepository;
+import excluz.excluz.domain.event.eventApplicant.service.EventApplicantService;
+import excluz.excluz.domain.event.eventItem.dto.EventItemRequestDto;
+import excluz.excluz.domain.event.eventItem.repository.EventItemRepository;
+import excluz.excluz.domain.store.item.repository.ItemRepository;
+import excluz.excluz.domain.store.store.repository.StoreRepository;
+import excluz.excluz.domain.streamer.repository.StreamerRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.test.util.ReflectionTestUtils;
 
-//         // Event 객체 생성
-//         event = Event.builder()
-//                 .store(store)
-//                 .numberOfWinners(10)
-//                 .participantCondition(ParticipantCondition.ALL_USERS)
-//                 .selectionMethod(SelectionMethod.RANDOM_DRAW)
-//                 .startDatetime(LocalDateTime.now())
-//                 .endDatetime(LocalDateTime.now().plusDays(1))
-//                 .generatedCode("UNIQUE_CODE")
-//                 .build();
-//         event.setId(2);
-//     }
+import java.time.LocalDateTime;
+import java.util.*;
 
-//     @Test
-//     void createEvent_Success() {
-//         // 준비
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
 
-//         EventItemRequestDto eventItemRequestDto = new EventItemRequestDto(item.getId(), 5);
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class EventServiceTest {
+    // 모의 객체 (각 Repository)
+    @Mock
+    private StreamerRepository streamerRepository;
+    @Mock
+    private StoreRepository storeRepository;
+    @Mock
+    private ItemRepository itemRepository;
+    @Mock
+    private EventRepository eventRepository;
+    @Mock
+    private EventItemRepository eventItemRepository;
+    @Mock
+    private EventApplicantRepository eventApplicantRepository;
 
-//         EventRequestDto eventRequestDto = EventRequestDto.builder()
-//                 .storeId(store.getId())
-//                 .numberOfWinners(10)
-//                 .participantCondition("ALL_USERS")
-//                 .selectionMethod("RANDOM_DRAW")
-//                 .startDatetime(LocalDateTime.now())
-//                 .endDatetime(LocalDateTime.now().plusDays(1))
-//                 .eventItems(Collections.singletonList(eventItemRequestDto))
-//                 .build();
+    // 실제 테스트 객체
+    @InjectMocks
+    private EventService eventService;
+    @InjectMocks
+    private EventApplicantService eventApplicantService;
 
+    // 테스트에서 사용할 엔티티들
+    private Streamer testStreamer;
+    private Store testStore;
+    private Item testItem1;
+    private Item testItem2;
+    private EventApplicantRequestDto testRequestDto;
+    private String uniqueSuffix;
+    private final String testCode = "TEST_CODE";
+    private Event testEvent;
 
-//         when(storeRepository.findById(store.getId())).thenReturn(Optional.of(store));
-//         when(itemRepository.findById(item.getId())).thenReturn(Optional.of(item));
-//         when(eventRepository.save(any(Event.class))).thenReturn(event);
-//         when(eventItemRepository.saveAll(anyList())).thenReturn(null);
+    @BeforeEach
+    public void setup() {
+        // 각 테스트마다 중복 데이터를 피하기 위한 고유 접미사
+        uniqueSuffix = UUID.randomUUID().toString().substring(0, 4);
 
-//         // 실행
-//         EventResponseDto responseDto = eventService.createEvent(eventRequestDto);
+        // 단순 생성 (필요시 빌더 사용)
+        testStreamer = Streamer.builder()
+                .name("스트리머" + uniqueSuffix)
+                .nickName("스트리머" + uniqueSuffix)
+                .phoneNumber("01012341234")
+                .email("streamer" + uniqueSuffix + "@example.com")
+                .password("password")
+                .build();
+        ReflectionTestUtils.setField(testStreamer, "id", 1);
 
-//         // 검증
-//         assertNotNull(responseDto);
-//         assertEquals(event.getId(), responseDto.getId());
-//         assertEquals(event.getNumberOfWinners(), responseDto.getNumberOfWinners());
-//         assertEquals(event.getParticipantCondition().name(), responseDto.getParticipantCondition());
-//         assertEquals(event.getSelectionMethod().name(), responseDto.getSelectionMethod());
+        testStore = Store.builder()
+                .streamer(testStreamer)
+                .storeName("StoreName" + uniqueSuffix)
+                .address("StoreAddress" + uniqueSuffix)
+                .registrationNumber("RegNum" + uniqueSuffix)
+                .build();
+        ReflectionTestUtils.setField(testStore, "id", 1);
 
-//         // 호출 검증
-//         verify(storeRepository, times(1)).findById(store.getId());
-//         System.out.println(storeRepository.findById(store.getId()));
-//         verify(itemRepository, times(1)).findById(item.getId());
-//         System.out.println(itemRepository.findById(item.getId()));
-//         verify(eventRepository, times(1)).save(any(Event.class));
-//         verify(eventItemRepository, times(1)).saveAll(anyList());
-//     }
+        testItem1 = Item.builder()
+                .store(testStore)
+                .itemName("TestItem" + uniqueSuffix + "1")
+                .explanation("설명")
+                .price(5000)
+                .remainingQuantity(100)
+                .build();
+        ReflectionTestUtils.setField(testItem1, "id", 1);
 
-//     @Test
-//     void createEvent_StoreNotFound() {
-//         // 준비
-//         EventRequestDto eventRequestDto = EventRequestDto.builder()
-//                 .storeId(999) // 존재하지 않는 ID
-//                 .numberOfWinners(10)
-//                 .participantCondition("ALL_USERS")
-//                 .selectionMethod("RANDOM_DRAW")
-//                 .startDatetime(LocalDateTime.now())
-//                 .endDatetime(LocalDateTime.now().plusDays(1))
-//                 .eventItems(null)
-//                 .build();
-
-//         when(storeRepository.findById(999)).thenReturn(Optional.empty());
-
-//         // 실행 및 검증
-//         Exception exception = assertThrows(IllegalArgumentException.class, () -> {
-//             eventService.createEvent(eventRequestDto);
-//         });
-
-//         assertEquals("해당 스토어를 찾을 수 없습니다.", exception.getMessage());
-//         verify(storeRepository, times(1)).findById(999);
-//     }
-
-//     @Test
-//     void createEvent_ItemNotFound() {
-//         // 준비
-//         EventItemRequestDto eventItemRequestDto = new EventItemRequestDto(999, 5);
-
-//         EventRequestDto eventRequestDto = EventRequestDto.builder()
-//                 .storeId(store.getId())
-//                 .numberOfWinners(10)
-//                 .participantCondition("ALL_USERS")
-//                 .selectionMethod("RANDOM_DRAW")
-//                 .startDatetime(LocalDateTime.now())
-//                 .endDatetime(LocalDateTime.now().plusDays(1))
-//                 .eventItems(Collections.singletonList(eventItemRequestDto))
-//                 .build();
-
-//         when(storeRepository.findById(store.getId())).thenReturn(Optional.of(store));
-//         when(itemRepository.findById(999)).thenReturn(Optional.empty());
-
-//         // 실행 및 검증
-//         Exception exception = assertThrows(IllegalArgumentException.class, () -> {
-//             eventService.createEvent(eventRequestDto);
-//         });
-
-//         assertEquals("ID가 999인 아이템을 찾을 수 없습니다.", exception.getMessage());
-//         verify(storeRepository, times(1)).findById(store.getId());
-//         verify(itemRepository, times(1)).findById(999);
-//     }
-
-//     @Test
-//     void createEvent_InvalidQuantity() {
-//         // 준비
-//         EventItemRequestDto eventItemRequestDto = new EventItemRequestDto(item.getId(), 0);
+        testItem2 = Item.builder()
+                .store(testStore)
+                .itemName("TestItem" + uniqueSuffix + "2")
+                .explanation("설명2")
+                .price(10000)
+                .remainingQuantity(100)
+                .build();
+        ReflectionTestUtils.setField(testItem2, "id", 2);
 
 
-//         EventRequestDto eventRequestDto = EventRequestDto.builder()
-//                 .storeId(store.getId())
-//                 .numberOfWinners(10)
-//                 .participantCondition("ALL_USERS")
-//                 .selectionMethod("RANDOM_DRAW")
-//                 .startDatetime(LocalDateTime.now())
-//                 .endDatetime(LocalDateTime.now().plusDays(1))
-//                 .eventItems(Collections.singletonList(eventItemRequestDto))
-//                 .build();
 
-//         when(storeRepository.findById(store.getId())).thenReturn(Optional.of(store));
-//         when(itemRepository.findById(item.getId())).thenReturn(Optional.of(item));
+        when(streamerRepository.findById(testStreamer.getId()))
+                .thenReturn(Optional.of(testStreamer));
 
-//         // 실행 및 검증
-//         Exception exception = assertThrows(IllegalArgumentException.class, () -> {
-//             eventService.createEvent(eventRequestDto);
-//         });
+        when(storeRepository.findById(testStore.getId()))
+                .thenReturn(Optional.of(testStore));
 
-//         assertEquals("아이템 ID " + item.getId() + "의 수량은 0보다 커야 합니다.", exception.getMessage());
-//         verify(storeRepository, times(1)).findById(store.getId());
-//         verify(itemRepository, times(1)).findById(item.getId());
-//     }
+        when(itemRepository.findById(testItem1.getId()))
+                .thenReturn(Optional.of(testItem1));
+        when(itemRepository.findById(testItem2.getId()))
+                .thenReturn(Optional.of(testItem2));
 
-//     @Test
-//     void createEvent_NoEventItems() {
-//         // 준비
-//         EventRequestDto eventRequestDto = EventRequestDto.builder()
-//                 .storeId(store.getId())
-//                 .numberOfWinners(10)
-//                 .participantCondition("ALL_USERS")
-//                 .selectionMethod("RANDOM_DRAW")
-//                 .startDatetime(LocalDateTime.now())
-//                 .endDatetime(LocalDateTime.now().plusDays(1))
-//                 .eventItems(null) // 아이템 없이 이벤트 생성
-//                 .build();
+        when(storeRepository.save(any(Store.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+        when(streamerRepository.save(any(Streamer.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+        when(itemRepository.save(any(Item.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+//         when(eventRepository.save(any(Event.class)))
+//                 .thenAnswer(invocation -> {
+//                     Event e = invocation.getArgument(0);
+//                     ReflectionTestUtils.setField(e, "id", 1);
+//                     return e;
+//                 });
 
-//         when(storeRepository.findById(store.getId())).thenReturn(Optional.of(store));
-//         when(eventRepository.save(any(Event.class))).thenReturn(event);
 
-//         // 실행
-//         var responseDto = eventService.createEvent(eventRequestDto);
+        testRequestDto = EventApplicantRequestDto.builder()
+                .email("test@example.com")
+                .applicantName("테스트사용자")
+                .applicantPassword("password")
+                .deliveryAddress("주소")
+                .build();
 
-//         // 검증
-//         assertNotNull(responseDto);
-//         assertEquals(event.getId(), responseDto.getId());
-//         assertEquals(event.getNumberOfWinners(), responseDto.getNumberOfWinners());
+        testEvent = createTestEvent();
+    }
 
-//         // 호출 검증
-//         verify(storeRepository, times(1)).findById(store.getId());
-//         verify(eventRepository, times(1)).save(any(Event.class));
-//         verify(eventItemRepository, never()).saveAll(anyList());
-//         verify(itemRepository, never()).findById(anyInt());
-//     }
-// }
+// --------------------1. createEvent 테스트--------------------
+
+    @Test
+    @DisplayName("success: 이벤트 생성")
+    public void testCreateEventSuccess() {
+        // given
+        List<EventItemRequestDto> eventItemList = new ArrayList<>();
+        eventItemList.add(new EventItemRequestDto(testItem1.getId(), 5));
+        eventItemList.add(new EventItemRequestDto(testItem2.getId(), 2));
+        EventRequestDto requestDto = EventRequestDto.builder()
+                .storeId(testStore.getId())
+                .numberOfWinners(3)
+                .participantCondition(ParticipantCondition.ALL_USERS.name())
+                .selectionMethod(SelectionMethod.RANDOM_DRAW.name())
+                .startDatetime(LocalDateTime.now().minusMinutes(1))
+                .endDatetime(LocalDateTime.now().plusDays(1))
+                .eventItemList(eventItemList)
+                .build();
+
+        // when
+        when(eventRepository.save(any(Event.class))).thenAnswer(invocation -> {
+            Event event = invocation.getArgument(0);
+            ReflectionTestUtils.setField(event, "id", 1);
+            return event;
+        });
+
+        EventResponseDto responseDto = eventService.createEvent(testStreamer.getId(), requestDto);
+
+        // then
+        Assertions.assertThat(responseDto).isNotNull();
+        Assertions.assertThat(responseDto.getId()).isNotNull();
+        Assertions.assertThat(responseDto.getStreamerStoreId()).isEqualTo(testStore.getId());
+        Assertions.assertThat(responseDto.getNumberOfWinners()).isEqualTo(3);
+        Assertions.assertThat(responseDto.getIsCompleted()).isFalse();
+        Assertions.assertThat(responseDto.getParticipantCondition()).isEqualTo(ParticipantCondition.ALL_USERS.name());
+        Assertions.assertThat(responseDto.getSelectionMethod()).isEqualTo(SelectionMethod.RANDOM_DRAW.name());
+        Assertions.assertThat(responseDto.getGeneratedCode()).isNotNull();
+        Assertions.assertThat(responseDto.getEventItemList()).hasSize(2);
+
+        // 추가: 이벤트 저장 호출 여부 검증
+        verify(eventRepository, times(1)).save(any(Event.class));
+    }
+
+    @Test
+    @DisplayName("fail: 잘못된 스토어 ID로 이벤트 생성 시")
+    public void testCreateEventFailure_InvalidStore() {
+        // given
+        List<EventItemRequestDto> eventItemList = new ArrayList<>();
+        eventItemList.add(new EventItemRequestDto(testItem1.getId(), 5));
+        EventRequestDto requestDto = EventRequestDto.builder()
+                .storeId(-999)   // 존재하지 않는 스토어 ID
+                .numberOfWinners(3)
+                .participantCondition(ParticipantCondition.ALL_USERS.name())
+                .selectionMethod(SelectionMethod.RANDOM_DRAW.name())
+                .startDatetime(LocalDateTime.now().minusMinutes(1))
+                .endDatetime(LocalDateTime.now().plusDays(1))
+                .eventItemList(eventItemList)
+                .build();
+
+        when(storeRepository.findById(-999)).thenReturn(Optional.empty());
+
+        // when, then
+        Assertions.assertThatThrownBy(() -> {
+                    eventService.createEvent(testStreamer.getId(), requestDto);
+                })
+                .isInstanceOf(NotFoundException.class)
+                .satisfies(ex -> {
+                    NotFoundException notFoundEx = (NotFoundException) ex;
+                    Assertions.assertThat(notFoundEx.getErrorCode()).isEqualTo(ErrorCode.STORE_NOT_FOUND);
+                });
+    }
+
+    @Test
+    @DisplayName("fail: 다른 사람의 스토어로 이벤트 생성 시 -> STORE_NOT_MATCH")
+    public void testCreateEventFailure_StoreNotMatch() {
+        // given
+        // testStreamer(id=1)와는 다른 스트리머 생성
+        String tempSuffix = UUID.randomUUID().toString().substring(0, 4);
+        Streamer streamer2 = Streamer.builder()
+                .name("스트리머" + tempSuffix)
+                .nickName("스트리머" + tempSuffix)
+                .phoneNumber("01000000000")
+                .email("streamer2" + tempSuffix + "@example.com")
+                .password("password")
+                .build();
+        ReflectionTestUtils.setField(streamer2, "id", 2);
+    }
+
+    @Test
+    @DisplayName("fail: 스토어에 소속되지 않은 아이템으로 이벤트 생성 시")
+    public void testCreateEventFailure_ItemNotBelongToStore() {
+        // given
+        // 타 스토어 소속 아이템 준비
+        String tempSuffix = UUID.randomUUID().toString().substring(0, 4);
+        Streamer streamer2 = Streamer.builder()
+                .name("스트리머" + tempSuffix)
+                .nickName("스트리머" + tempSuffix)
+                .phoneNumber("01000000000")
+                .email("streamer2" + tempSuffix + "@example.com")
+                .password("password")
+                .build();
+        ReflectionTestUtils.setField(streamer2, "id", 2);
+        Store otherStore = Store.builder()
+                .streamer(streamer2)
+                .storeName("OtherStore" + tempSuffix)
+                .address("OtherAddress" + tempSuffix)
+                .registrationNumber("OtherReg" + tempSuffix)
+                .build();
+        ReflectionTestUtils.setField(otherStore, "id", 2);
+        Item otherItem = Item.builder()
+                .store(otherStore)
+                .itemName("OtherItem" + tempSuffix)
+                .explanation("Other Desc")
+                .price(7000)
+                .remainingQuantity(50)
+                .build();
+        ReflectionTestUtils.setField(otherItem, "id", 3);
+
+        List<EventItemRequestDto> eventItemList = new ArrayList<>();
+        // 기본 스토어(testStore)와 다른 아이템 사용
+        eventItemList.add(new EventItemRequestDto(otherItem.getId(), 2));
+        EventRequestDto requestDto = EventRequestDto.builder()
+                .storeId(testStore.getId())  // 기본 스토어 id 사용
+                .numberOfWinners(3)
+                .participantCondition(ParticipantCondition.ALL_USERS.name())
+                .selectionMethod(SelectionMethod.RANDOM_DRAW.name())
+                .startDatetime(LocalDateTime.now().minusMinutes(1))
+                .endDatetime(LocalDateTime.now().plusDays(1))
+                .eventItemList(eventItemList)
+                .build();
+
+        when(storeRepository.findById(testStore.getId())).thenReturn(Optional.of(testStore));
+        // 해당 아이템 id 조회 시, 타 스토어 소속 아이템 반환
+        when(itemRepository.findById(otherItem.getId())).thenReturn(Optional.of(otherItem));
+
+        // when, then
+        Assertions.assertThatThrownBy(() -> {
+                    eventService.createEvent(testStreamer.getId(), requestDto);
+                }).isInstanceOf(UnauthorizedException.class)
+                .satisfies(ex -> {
+                    UnauthorizedException notFoundEx = (UnauthorizedException) ex;
+                    Assertions.assertThat(notFoundEx.getErrorCode()).isEqualTo(ErrorCode.ITEM_NOT_MATCH);
+                });
+    }
+
+    @Test
+    @DisplayName("fail: 이미 과거인 종료 시간으로 이벤트 생성 시 -> EVENT_ENDDATETIME_TOO_EARLY")
+    public void testCreateEventFailure_EndDateTimeTooEarly() {
+        // given
+        List eventItemList = Collections.singletonList(
+                new EventItemRequestDto(testItem1.getId(), 5)
+        );
+        // 종료 시간이 현재시간보다 과거가 되도록 설정
+        EventRequestDto requestDto = EventRequestDto.builder()
+                .storeId(testStore.getId())
+                .numberOfWinners(3)
+                .participantCondition(ParticipantCondition.ALL_USERS.name())
+                .selectionMethod(SelectionMethod.RANDOM_DRAW.name())
+                .startDatetime(LocalDateTime.now().minusMinutes(10))
+                .endDatetime(LocalDateTime.now().minusMinutes(1)) // 과거 시간
+                .eventItemList(eventItemList)
+                .build();
+        // when, then
+        Assertions.assertThatThrownBy(() -> eventService.createEvent(testStreamer.getId(), requestDto))
+                .isInstanceOf(BadRequestException.class)
+                .satisfies(ex -> {
+                    BadRequestException be = (BadRequestException) ex;
+                    Assertions.assertThat(be.getErrorCode()).isEqualTo(ErrorCode.EVENT_ENDDATETIME_TOO_EARLY);
+                });
+    }
+
+    @Test
+    @DisplayName("fail: 존재하지 않는 아이템으로 이벤트 생성 시 -> ITEM_NOT_FOUND")
+    public void testCreateEventFailure_ItemNotFound() {
+        // given
+        int nonExistentItemId = 999;
+        when(itemRepository.findById(nonExistentItemId)).thenReturn(Optional.empty());
+        List<EventItemRequestDto> eventItemList = Collections.singletonList(
+                new EventItemRequestDto(nonExistentItemId, 5)
+        );
+        EventRequestDto requestDto = EventRequestDto.builder()
+                .storeId(testStore.getId())
+                .numberOfWinners(3)
+                .participantCondition(ParticipantCondition.ALL_USERS.name())
+                .selectionMethod(SelectionMethod.RANDOM_DRAW.name())
+                .startDatetime(LocalDateTime.now().minusMinutes(1))
+                .endDatetime(LocalDateTime.now().plusDays(1))
+                .eventItemList(eventItemList)
+                .build();
+
+        // when, then
+        Assertions.assertThatThrownBy(() -> eventService.createEvent(testStreamer.getId(), requestDto))
+                .isInstanceOf(NotFoundException.class)
+                .satisfies(ex -> {
+                    NotFoundException nfe = (NotFoundException) ex;
+                    Assertions.assertThat(nfe.getErrorCode()).isEqualTo(ErrorCode.ITEM_NOT_FOUND);
+                });
+    }
+
+
+// --------------------2. getAllEvents, getEvent 테스트--------------------
+
+    @Test
+    @DisplayName("success: 전체 이벤트 목록 조회")
+    public void testGetAllEventsSuccess() {
+        // given
+        Event event1 = createTestEvent();
+        ReflectionTestUtils.setField(event1, "id", 1);
+        Event event2 = createTestEvent();
+        ReflectionTestUtils.setField(event2, "id", 2);
+        List<Event> events = Arrays.asList(event1, event2);
+        when(eventRepository.findAll()).thenReturn(events);
+
+        // when
+        List<EventResponseDto> eventList = eventService.getAllEvents();
+
+        // then
+        Assertions.assertThat(eventList).isNotNull();
+        Assertions.assertThat(eventList.size()).isGreaterThanOrEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("success: 단건 이벤트 조회")
+    public void testGetEventSuccess() {
+        // given
+        Event event = createTestEvent();
+        ReflectionTestUtils.setField(event, "id", 1);
+        // stubbing: 이벤트 단건 조회
+        when(eventRepository.findById(1)).thenReturn(Optional.of(event));
+        // stubbing: 이벤트 아이템 조회 (간단히 빈 리스트)
+        when(eventItemRepository.findByEvent(event)).thenReturn(new ArrayList<>());
+
+        // when
+        EventResponseDto fetchedEvent = eventService.getEvent(1);
+
+        // then
+        Assertions.assertThat(fetchedEvent).isNotNull();
+        Assertions.assertThat(fetchedEvent.getId()).isEqualTo(1);
+        Assertions.assertThat(fetchedEvent.getEventItemList()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("fail: 존재하지 않는 이벤트 단건 조회")
+    public void testGetEventFailure_NotFound() {
+        // given
+        when(eventRepository.findById(-999)).thenReturn(Optional.empty());
+
+        // when, then
+        Assertions.assertThatThrownBy(() -> {
+                    eventService.getEvent(-999);
+                })
+                .isInstanceOf(NotFoundException.class)
+                .satisfies(ex -> {
+                    NotFoundException nfe = (NotFoundException) ex;
+                    Assertions.assertThat(nfe.getErrorCode()).isEqualTo(ErrorCode.EVENT_NOT_FOUND);
+                });
+    }
+
+// --------------------3. closeEvent 테스트--------------------
+
+    @Test
+    @DisplayName("success: 이벤트 마감")
+    public void testCloseEventSuccess() {
+        // given
+        Event event = createTestEvent();
+        ReflectionTestUtils.setField(event, "id", 1);
+        ReflectionTestUtils.setField(event, "numberOfWinners", 3);
+        ReflectionTestUtils.setField(event, "isCompleted", false);
+        ReflectionTestUtils.setField(event, "selectionMethod", SelectionMethod.RANDOM_DRAW);
+
+        // stubbing: 조회
+        when(eventRepository.findById(1)).thenReturn(Optional.of(event));
+
+        // stubbing: 이벤트 마감 후, eventApplicantRepository.findByEvent()에서 10명의 지원자 반환
+        List<EventApplicant> applicantList = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            EventApplicant applicant = EventApplicant.builder()
+                    .event(event)
+                    .email("applicant" + i + "@example.com")
+                    .applicantName("지원자" + i)
+                    .applicantPassword("password")
+                    .deliveryAddress("Address" + i)
+                    .applicantStatus(ApplicantStatus.WAITING)
+                    .build();
+            ReflectionTestUtils.setField(applicant, "id", i + 1);
+            applicantList.add(applicant);
+        }
+        when(eventApplicantRepository.findByEvent(event)).thenReturn(applicantList);
+
+        // when
+        EventClosingResponseDto closingResponse = eventService.closeEvent(testStreamer.getId(), 1);
+
+        // then
+        Assertions.assertThat(closingResponse).isNotNull();
+        Assertions.assertThat(closingResponse.getId()).isEqualTo(1);
+        Assertions.assertThat(closingResponse.getIsCompleted()).isTrue();
+        Assertions.assertThat(closingResponse.getEventApplicants()).hasSize(10);
+
+        // 당첨자 수 검증 (예시로 실제 로직이 당첨자 수 업데이트 후 ApplicantStatus 변경)
+        int winnerCount = (int) closingResponse.getEventApplicants().stream().filter(a -> a.getApplicantStatus() == ApplicantStatus.WINNER).count();
+        Assertions.assertThat(winnerCount).isEqualTo(event.getNumberOfWinners());
+    }
+
+
+    @Test
+    @DisplayName("fail: 존재하지 않는 이벤트로 closeEvent 호출 -> EVENT_NOT_FOUND")
+    public void testCloseEventFailure_EventNotFound() {
+        // given
+        when(eventRepository.findById(-999)).thenReturn(Optional.empty());
+
+        // when, then
+        Assertions.assertThatThrownBy(() -> eventService.closeEvent(testStreamer.getId(), -999))
+                .isInstanceOf(NotFoundException.class)
+                .satisfies(ex -> {
+                    NotFoundException nfe = (NotFoundException) ex;
+                    Assertions.assertThat(nfe.getErrorCode()).isEqualTo(ErrorCode.EVENT_NOT_FOUND);
+                });
+    }
+
+    @Test
+    @DisplayName("fail: 존재하지 않는 스트리머 ID로 closeEvent 호출 -> USER_NOT_FOUND")
+    public void testCloseEventFailure_StreamerNotFound() {
+        // given
+        int invalidStreamerId = 9999;
+        when(streamerRepository.findById(invalidStreamerId)).thenReturn(Optional.empty());
+
+        // 이벤트는 존재한다고 가정
+        Event event = createTestEvent();
+        ReflectionTestUtils.setField(event, "id", 1);
+        when(eventRepository.findById(1)).thenReturn(Optional.of(event));
+
+        // when, then
+        Assertions.assertThatThrownBy(() -> eventService.closeEvent(invalidStreamerId, 1))
+                .isInstanceOf(NotFoundException.class)
+                .satisfies(ex -> {
+                    NotFoundException nfe = (NotFoundException) ex;
+                    Assertions.assertThat(nfe.getErrorCode()).isEqualTo(ErrorCode.USER_NOT_FOUND);
+                });
+    }
+
+    @Test
+    @DisplayName("fail: 다른 스트리머가 이벤트 마감 -> STORE_NOT_MATCH")
+    public void testCloseEventFailure_StoreNotMatch() {
+        // given
+        // testStreamer != otherStreamer
+        String tempSuffix = UUID.randomUUID().toString().substring(0, 4);
+        Streamer otherStreamer = Streamer.builder()
+                .name("다른스트리머" + tempSuffix)
+                .nickName("다른스트리머" + tempSuffix)
+                .phoneNumber("01011111111")
+                .email("other" + tempSuffix + "@example.com")
+                .password("pw")
+                .build();
+        ReflectionTestUtils.setField(otherStreamer, "id", 2);
+
+        // 다른 스트리머 소유 이벤트
+        Store otherStore = Store.builder()
+                .streamer(otherStreamer)
+                .storeName("OtherStore" + tempSuffix)
+                .address("OtherAddress" + tempSuffix)
+                .registrationNumber("OtherReg" + tempSuffix)
+                .build();
+        ReflectionTestUtils.setField(otherStore, "id", 200);
+
+        Event event = Event.builder()
+                .store(otherStore)
+                .numberOfWinners(3)
+                .participantCondition(ParticipantCondition.ALL_USERS)
+                .selectionMethod(SelectionMethod.FIRST_COME_FIRST_SERVED)
+                .startDatetime(LocalDateTime.now().minusDays(1))
+                .endDatetime(LocalDateTime.now().plusDays(1))
+                .generatedCode("OTHER_CODE")
+                .build();
+        ReflectionTestUtils.setField(event, "id", 99);
+
+        when(streamerRepository.findById(testStreamer.getId())).thenReturn(Optional.of(testStreamer));
+        when(eventRepository.findById(99)).thenReturn(Optional.of(event));
+
+        // when, then
+        Assertions.assertThatThrownBy(() -> eventService.closeEvent(testStreamer.getId(), 99))
+                .isInstanceOf(UnauthorizedException.class)
+                .satisfies(ex -> {
+                    UnauthorizedException ue = (UnauthorizedException) ex;
+                    Assertions.assertThat(ue.getErrorCode()).isEqualTo(ErrorCode.STORE_NOT_MATCH);
+                });
+    }
+
+    @Test
+    @DisplayName("fail: 이미 취소된 이벤트 마감 -> EVENT_ALREADY_CANCELED")
+    public void testCloseEventFailure_AlreadyCanceled() {
+        // given
+        Event event = createTestEvent();
+        ReflectionTestUtils.setField(event, "id", 1);
+        ReflectionTestUtils.setField(event, "isDeleted", true);  // 이미 취소된 상태
+
+        when(streamerRepository.findById(testStreamer.getId())).thenReturn(Optional.of(testStreamer));
+        when(eventRepository.findById(1)).thenReturn(Optional.of(event));
+
+        // when, then
+        Assertions.assertThatThrownBy(() -> eventService.closeEvent(testStreamer.getId(), 1))
+                .isInstanceOf(BadRequestException.class)
+                .satisfies(ex -> {
+                    BadRequestException be = (BadRequestException) ex;
+                    Assertions.assertThat(be.getErrorCode()).isEqualTo(ErrorCode.EVENT_ALREADY_CANCELED);
+                });
+    }
+
+    @Test
+    @DisplayName("fail: 이미 마감된 이벤트 마감 -> EVENT_ALREADY_CLOSED")
+    public void testCloseEventFailure_AlreadyClosed() {
+        // given
+        Event event = createTestEvent();
+        ReflectionTestUtils.setField(event, "id", 2);
+        ReflectionTestUtils.setField(event, "isCompleted", true); // 이미 마감된 상태
+
+        when(streamerRepository.findById(testStreamer.getId())).thenReturn(Optional.of(testStreamer));
+        when(eventRepository.findById(2)).thenReturn(Optional.of(event));
+
+        // when, then
+        Assertions.assertThatThrownBy(() -> eventService.closeEvent(testStreamer.getId(), 2))
+                .isInstanceOf(BadRequestException.class)
+                .satisfies(ex -> {
+                    BadRequestException be = (BadRequestException) ex;
+                    Assertions.assertThat(be.getErrorCode()).isEqualTo(ErrorCode.EVENT_ALREADY_CLOSED);
+                });
+    }
+
+// --------------------4. cancelEvent 테스트--------------------
+
+    @Test
+    @DisplayName("success: 이벤트 취소")
+    public void testCancelEventSuccess() {
+        // given
+        // 이벤트 생성 시 차감될 재고 계산을 위해 EventItemRequestDto 준비
+        List<EventItemRequestDto> eventItemList = new ArrayList<>();
+
+        eventItemList.add(new EventItemRequestDto(testItem1.getId(), 2));
+
+
+        EventRequestDto requestDto = EventRequestDto.builder()
+                .storeId(testStore.getId())
+                .numberOfWinners(3)
+                .participantCondition(ParticipantCondition.ALL_USERS.name())
+                .selectionMethod(SelectionMethod.RANDOM_DRAW.name())
+                .startDatetime(LocalDateTime.now().minusMinutes(1))
+                .endDatetime(LocalDateTime.now().plusDays(1))
+                .eventItemList(eventItemList)
+                .build();
+        // stubbing: store, item, 이벤트 저장
+        when(storeRepository.findById(testStore.getId())).thenReturn(Optional.of(testStore));
+        when(itemRepository.findById(testItem1.getId())).thenReturn(Optional.of(testItem1));
+        when(eventRepository.save(any(Event.class))).thenAnswer(invocation -> {
+            Event event = invocation.getArgument(0);
+            ReflectionTestUtils.setField(event, "id", 1);
+            return event;
+        });
+        when(eventItemRepository.save(any(EventItem.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        EventResponseDto createdEvent = eventService.createEvent(testStreamer.getId(), requestDto);
+        // 취소 전 상태: isDeleted false, 아이템 재고는 testItem1.remainingQuantity==100
+        Event event = createTestEvent();
+        ReflectionTestUtils.setField(event, "id", createdEvent.getId());
+        ReflectionTestUtils.setField(event, "isDeleted", false);
+        EventItem eventItem = new EventItem(event, testItem1, 2);
+        ReflectionTestUtils.setField(eventItem, "id", 10);
+
+        when(eventRepository.findById(createdEvent.getId())).thenReturn(Optional.of(event));
+        when(eventItemRepository.findByEvent(event)).thenReturn(List.of(eventItem));
+
+        // when
+        eventService.cancelEvent(testStreamer.getId(), createdEvent.getId());
+
+        // then: 이벤트 취소 후 상태 업데이트 검증 (isDeleted true)
+        Assertions.assertThat(event.getIsDeleted()).isTrue();
+        // 재고 복구: 테스트에서는 testItem1.remainingQuantity 원래 100 값으로 복구된다고 가정
+        when(itemRepository.findById(testItem1.getId())).thenReturn(Optional.of(testItem1));
+        Item itemReloaded = itemRepository.findById(testItem1.getId()).orElse(null);
+        Assertions.assertThat(itemReloaded.getRemainingQuantity()).isEqualTo(100);
+    }
+
+    @Test
+    @DisplayName("fail: 마감된 이벤트 취소 시")
+    public void testCancelEventFailure_AlreadyCompleted() {
+        // given
+        Event event = createTestEvent();
+        ReflectionTestUtils.setField(event, "id", 1);
+        ReflectionTestUtils.setField(event, "isCompleted", true);
+        when(eventRepository.findById(1)).thenReturn(Optional.of(event));
+        when(streamerRepository.findById(event.getId())).thenReturn(Optional.of(testStreamer));
+
+
+        // when, then
+        Assertions.assertThatThrownBy(() -> {
+                    eventService.cancelEvent(testStreamer.getId(), 1);
+                })
+                .isInstanceOf(BadRequestException.class)
+                .satisfies(ex -> {
+                    BadRequestException badRequestException = (BadRequestException) ex;
+                    Assertions.assertThat(badRequestException.getErrorCode()).isEqualTo(ErrorCode.EVENT_ALREADY_CLOSED);
+                });
+    }
+
+    @Test
+    @DisplayName("fail: 존재하지 않는 이벤트 취소 시 -> EVENT_NOT_FOUND")
+    public void testCancelEventFailure_EventNotFound() {
+        // given
+        when(eventRepository.findById(-999)).thenReturn(Optional.empty()); // 잘못된 이벤트 ID
+
+        // when, then
+        Assertions.assertThatThrownBy(() -> eventService.cancelEvent(testStreamer.getId(), -999))
+                .isInstanceOf(NotFoundException.class)
+                .satisfies(ex -> {
+                    NotFoundException nfe = (NotFoundException) ex;
+                    Assertions.assertThat(nfe.getErrorCode()).isEqualTo(ErrorCode.EVENT_NOT_FOUND);
+                });
+    }
+
+    @Test
+    @DisplayName("fail: 존재하지 않는 스트리머 ID로 이벤트 취소 시 -> USER_NOT_FOUND")
+    public void testCancelEventFailure_StreamerNotFound() {
+        // given
+        int invalidStreamerId = 9999;
+        when(streamerRepository.findById(invalidStreamerId)).thenReturn(Optional.empty());
+
+        // 이벤트도 임시로 존재한다고 가정
+        Event event = createTestEvent();
+        ReflectionTestUtils.setField(event, "id", 1);
+        when(eventRepository.findById(1)).thenReturn(Optional.of(event));
+
+        // when, then
+        Assertions.assertThatThrownBy(() -> eventService.cancelEvent(invalidStreamerId, 1))
+                .isInstanceOf(NotFoundException.class)
+                .satisfies(ex -> {
+                    NotFoundException nfe = (NotFoundException) ex;
+                    Assertions.assertThat(nfe.getErrorCode()).isEqualTo(ErrorCode.USER_NOT_FOUND);
+                });
+    }
+
+
+    // --------------------7. applyForEvent 테스트--------------------
+    @Test
+    void testApplyForEventRandomDraw_Success() {
+        // given
+        EventApplicantRequestDto requestDto = EventApplicantRequestDto.builder()
+                .email("test@example.com")
+                .applicantName("테스트사용자")
+                .applicantPassword("password")
+                .deliveryAddress("주소")
+                .build();
+        Event testEvent = createTestEvent();
+        ReflectionTestUtils.setField(testEvent, "selectionMethod", SelectionMethod.RANDOM_DRAW);
+        String testCode = testEvent.getGeneratedCode();
+
+        when(eventRepository.findByGeneratedCode(testCode)).thenReturn(Optional.of(testEvent));
+
+        when(eventApplicantRepository.existsByEventAndEmail(eq(testEvent), eq(requestDto.getEmail()))).thenReturn(false);
+
+        when(eventApplicantRepository.save(any(EventApplicant.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+// when
+        EventApplicantResponseDto result = eventApplicantService.applyForEvent(testCode, requestDto);
+
+// then
+        Assertions.assertThat(result).isNotNull();
+        Assertions.assertThat(result.getApplicantStatus()).isEqualTo(ApplicantStatus.WAITING);
+    }
+
+    @Test
+    @DisplayName("(2') applyForEvent - FIRST_COME_FIRST_SERVED - LOSER (정원 초과)")
+    void testApplyForEventFirstCome_Success_Loser() {
+        // given
+        testEvent = createTestEvent(SelectionMethod.FIRST_COME_FIRST_SERVED, false, false);
+        // numberOfWinners=3이고 이미 3명 WINNER 존재
+        when(eventRepository.findByGeneratedCode(testCode))
+                .thenReturn(Optional.of(testEvent));
+        when(eventApplicantRepository.existsByEventAndEmail(eq(testEvent), eq(testRequestDto.getEmail())))
+                .thenReturn(false);
+        when(eventApplicantRepository.countByEventAndApplicantStatus(eq(testEvent), eq(ApplicantStatus.WINNER)))
+                .thenReturn(3);
+
+        when(eventApplicantRepository.save(any(EventApplicant.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        EventApplicantResponseDto result = eventApplicantService.applyForEvent(testCode, testRequestDto);
+
+        // then
+        Assertions.assertThat(result.getApplicantStatus()).isEqualTo(ApplicantStatus.LOSER);
+    }
+
+    /**
+     * (3) 예외 케이스 - GeneratedCode로 이벤트 찾을 수 없음
+     */
+    @Test
+    @DisplayName("(3) applyForEvent - EVENT_NOT_FOUND")
+    void testApplyForEvent_EventNotFound() {
+        // given
+        when(eventRepository.findByGeneratedCode(testCode))
+                .thenReturn(Optional.empty());
+
+        // when & then
+        Assertions.assertThatThrownBy(() ->
+                        eventApplicantService.applyForEvent(testCode, testRequestDto))
+                .isInstanceOf(NotFoundException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.EVENT_NOT_FOUND);
+    }
+
+    /**
+     * (4) 예외 케이스 - 이벤트가 이미 마감(isCompleted=true)
+     */
+    @Test
+    @DisplayName("(4) applyForEvent - EVENT_ALREADY_CLOSED")
+    void testApplyForEvent_AlreadyClosed() {
+        // given
+        ReflectionTestUtils.setField(testEvent, "isCompleted", true);
+        when(eventRepository.findByGeneratedCode(testCode))
+                .thenReturn(Optional.of(testEvent));
+
+        // when & then
+        Assertions.assertThatThrownBy(() ->
+                        eventApplicantService.applyForEvent(testCode, testRequestDto))
+                .isInstanceOf(BadRequestException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.EVENT_ALREADY_CLOSED);
+    }
+
+    /**
+     * (5) 예외 케이스 - 이벤트가 이미 취소(isDeleted=true)
+     */
+    @Test
+    @DisplayName("(5) applyForEvent - EVENT_ALREADY_CANCELED")
+    void testApplyForEvent_AlreadyCanceled() {
+        // given
+        ReflectionTestUtils.setField(testEvent, "isDeleted", true);
+        when(eventRepository.findByGeneratedCode(testCode))
+                .thenReturn(Optional.of(testEvent));
+
+        // when & then
+        Assertions.assertThatThrownBy(() ->
+                        eventApplicantService.applyForEvent(testCode, testRequestDto))
+                .isInstanceOf(BadRequestException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.EVENT_ALREADY_CANCELED);
+    }
+
+    /**
+     * (6) 예외 케이스 - 이벤트 시작 전(now < startDatetime)
+     */
+    @Test
+    @DisplayName("(6) applyForEvent - EVENT_APPLICANT_NOT_STARTED")
+    void testApplyForEvent_NotStarted() {
+        // given
+        // 지금보다 미래 시간에 시작하도록 설정
+        ReflectionTestUtils.setField(testEvent, "startDatetime", LocalDateTime.now().plusHours(1));
+        when(eventRepository.findByGeneratedCode(testCode))
+                .thenReturn(Optional.of(testEvent));
+
+        // when & then
+        Assertions.assertThatThrownBy(() ->
+                        eventApplicantService.applyForEvent(testCode, testRequestDto))
+                .isInstanceOf(BadRequestException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.EVENT_APPLICANT_NOT_STARTED);
+    }
+
+    /**
+     * (7) 예외 케이스 - 이벤트가 이미 종료(now > endDatetime)
+     */
+    @Test
+    @DisplayName("(7) applyForEvent - EVENT_APPLICANT_EXPIRED")
+    void testApplyForEvent_Expired() {
+        // given
+        // 이미 과거 끝난 시간
+        ReflectionTestUtils.setField(testEvent, "endDatetime", LocalDateTime.now().minusHours(1));
+        when(eventRepository.findByGeneratedCode(testCode))
+                .thenReturn(Optional.of(testEvent));
+
+        // when & then
+        Assertions.assertThatThrownBy(() ->
+                        eventApplicantService.applyForEvent(testCode, testRequestDto))
+                .isInstanceOf(BadRequestException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.EVENT_APPLICANT_EXPIRED);
+    }
+
+    /**
+     * (8) 예외 케이스 - 이미 같은 Email로 중복 지원
+     */
+    @Test
+    @DisplayName("(8) applyForEvent - EMAIL_ALREADY_EXISTS")
+    void testApplyForEvent_EmailAlreadyExists() {
+        // given
+        when(eventRepository.findByGeneratedCode(testCode))
+                .thenReturn(Optional.of(testEvent));
+        // 이미 같은 email로 EventApplicant가 있다고 가정
+        when(eventApplicantRepository.existsByEventAndEmail(eq(testEvent), eq(testRequestDto.getEmail())))
+                .thenReturn(true);
+
+        // when & then
+        Assertions.assertThatThrownBy(() ->
+                        eventApplicantService.applyForEvent(testCode, testRequestDto))
+                .isInstanceOf(BadRequestException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.EMAIL_ALREADY_EXISTS);
+    }
+
+
+
+// --------------------6. confirmReceipt 테스트--------------------
+
+    @Test
+    @DisplayName("success: 당첨자 수령 확정")
+    public void testConfirmReceiptSuccess() {
+        // given
+        Event event = createTestEvent();
+        ReflectionTestUtils.setField(event, "id", 1);
+        // stubbing: 이벤트 조회 (상세 stubbing 생략)
+        when(eventRepository.findById(1)).thenReturn(Optional.of(event));
+
+        EventApplicant applicant = EventApplicant.builder()
+                .event(event)
+                .email("confirm@example.com")
+                .applicantName("지원자")
+                .applicantPassword("password")
+                .deliveryAddress("기존주소")
+                .applicantStatus(ApplicantStatus.WINNER) // 당첨 상태
+                .build();
+        ReflectionTestUtils.setField(applicant, "id", 1);
+        when(eventApplicantRepository.findById(1)).thenReturn(Optional.of(applicant));
+        // confirmReceipt 후 저장 stubbing
+        when(eventApplicantRepository.save(any(EventApplicant.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        EventApplicantRequestDto updateRequest = EventApplicantRequestDto.builder()
+                .applicantName("변경된이름")
+                .deliveryAddress("변경된주소")
+                .build();
+
+        // when
+        EventApplicantResponseDto updatedResponse = eventApplicantService.confirmReceipt(1, updateRequest);
+
+        // then
+        Assertions.assertThat(updatedResponse).isNotNull();
+        Assertions.assertThat(updatedResponse.getId()).isEqualTo(1);
+        Assertions.assertThat(updatedResponse.getApplicantName()).isEqualTo("변경된이름");
+        Assertions.assertThat(updatedResponse.getDeliveryAddress()).isEqualTo("변경된주소");
+        Assertions.assertThat(updatedResponse.getApplicantStatus()).isEqualTo(ApplicantStatus.CONFIRMED);
+    }
+
+    @Test
+    @DisplayName("fail: 당첨이 아닌 지원자가 수령 확정 시")
+    public void testConfirmReceiptFailure_NotWinner() {
+        // given
+        Event event = createTestEvent();
+        ReflectionTestUtils.setField(event, "id", 1);
+        when(eventRepository.findById(1)).thenReturn(Optional.of(event));
+
+        EventApplicant applicant = EventApplicant.builder()
+                .event(event)
+                .email("nonWinner@example.com")
+                .applicantName("지원자")
+                .applicantPassword("password")
+                .deliveryAddress("주소")
+                .applicantStatus(ApplicantStatus.WAITING) // 당첨 아님
+                .build();
+        ReflectionTestUtils.setField(applicant, "id", 2);
+        when(eventApplicantRepository.findById(2)).thenReturn(Optional.of(applicant));
+
+        EventApplicantRequestDto updateRequest = EventApplicantRequestDto.builder()
+                .applicantName("이름변경")
+                .deliveryAddress("주소변경")
+                .build();
+
+        // when, then
+        Assertions.assertThatThrownBy(() -> {
+                    eventApplicantService.confirmReceipt(2, updateRequest);
+                })
+                .isInstanceOf(BadRequestException.class)
+                .satisfies(ex -> {
+                    BadRequestException be = (BadRequestException) ex;
+                    Assertions.assertThat(be.getErrorCode()).isEqualTo(ErrorCode.EVENT_APPLICANT_NOT_WINNER);
+                });
+    }
+
+
+    private Event createTestEvent() {
+        return createTestEvent(SelectionMethod.FIRST_COME_FIRST_SERVED, false, false);
+    }
+
+    private Event createTestEvent(SelectionMethod selectionMethod, boolean isCompleted, boolean isDeleted) {
+        Event event = Event.builder()
+                .store(testStore) // 실제 테스트에서는 Store 세팅
+                .numberOfWinners(3)
+                .generatedCode(testCode)
+                .participantCondition(ParticipantCondition.ALL_USERS)
+                .selectionMethod(selectionMethod)
+                .startDatetime(LocalDateTime.now().minusHours(1)) // 이미 시작된 상태
+                .endDatetime(LocalDateTime.now().plusHours(1))    // 아직 끝나지 않은 상태
+                .build();
+        ReflectionTestUtils.setField(event, "isCompleted", isCompleted);
+        ReflectionTestUtils.setField(event, "isDeleted", isDeleted);
+        return event;
+    }
+
+}

--- a/src/test/java/excluz/excluz/domain/event/service/EventServiceUnitTest.java
+++ b/src/test/java/excluz/excluz/domain/event/service/EventServiceUnitTest.java
@@ -1,6 +1,8 @@
 package excluz.excluz.domain.event.service;
 
 import excluz.excluz.common.entity.*;
+import excluz.excluz.common.exception.NotFoundException;
+import excluz.excluz.common.exception.error.ErrorCode;
 import excluz.excluz.domain.event.event.dto.EventClosingResponseDto;
 import excluz.excluz.domain.event.event.dto.EventRequestDto;
 import excluz.excluz.domain.event.event.dto.EventResponseDto;
@@ -18,6 +20,7 @@ import excluz.excluz.domain.event.eventItem.repository.EventItemRepository;
 import excluz.excluz.domain.store.item.repository.ItemRepository;
 import excluz.excluz.domain.store.store.repository.StoreRepository;
 import excluz.excluz.domain.streamer.repository.StreamerRepository;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -31,6 +34,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
 
 @SpringBootTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
@@ -163,185 +167,187 @@ public class EventServiceUnitTest {
                 .eventItemList(eventItemList)
                 .build();
 
-        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
-            eventService.createEvent(testStreamer.getId(), requestDto);
-        });
-        assertTrue(exception.getMessage().contains("해당 스토어를 찾을 수 없습니다."));
+        when(storeRepository.findById(-999)).thenReturn(Optional.empty());
+        Assertions.assertThatThrownBy(() -> {
+                    eventService.createEvent(testStreamer.getId(), requestDto);
+                })
+                .isInstanceOf(NotFoundException.class)
+                .hasMessageContaining(ErrorCode.STORE_NOT_FOUND.getMessage());
+}
+
+
+// 1-3. 잘못된 ID로 create
+@Test
+public void testCreateEventFailure_ItemNotBelongToStore() {
+    String uniqueSuffix = UUID.randomUUID().toString().substring(0, 4);
+    Streamer streamer2 = Streamer.builder()
+            .name("스트리머" + uniqueSuffix)
+            .nickName("스트리머" + uniqueSuffix)
+            .phoneNumber("010" + ((int) (Math.random() * 90000000 + 10000000)))
+            .email("streamer2" + uniqueSuffix + "@example.com")
+            .password("password")
+            .build();
+    streamerRepository.save(streamer2);
+
+    Store otherStore = Store.builder()
+            .streamer(streamer2)
+            .storeName("OtherStore" + uniqueSuffix)
+            .address("OtherAddress" + uniqueSuffix)
+            .registrationNumber("OtherReg" + uniqueSuffix)
+            .build();
+    otherStore = storeRepository.save(otherStore);
+
+    Item otherItem = Item.builder()
+            .store(otherStore)
+            .itemName("OtherItem" + uniqueSuffix)
+            .explanation("Other Desc")
+            .price(7000)
+            .remainingQuantity(50)
+            .build();
+    otherItem = itemRepository.save(otherItem);
+
+    List<EventItemRequestDto> eventItemList = new ArrayList<>();
+    // 기존 스토어에 속하지 않는 아이템 사용
+    eventItemList.add(new EventItemRequestDto(otherItem.getId(), 2));
+
+    EventRequestDto requestDto = EventRequestDto.builder()
+            .storeId(testStore.getId())  // 기본 store
+            .numberOfWinners(3)
+            .participantCondition(ParticipantCondition.ALL_USERS.name())
+            .selectionMethod(SelectionMethod.RANDOM_DRAW.name())
+            .startDatetime(LocalDateTime.now().minusMinutes(1))
+            .endDatetime(LocalDateTime.now().plusDays(1))
+            .eventItemList(eventItemList)
+            .build();
+
+    Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+        eventService.createEvent(testStreamer.getId(), requestDto);
+    });
+    assertTrue(exception.getMessage().contains("현재 스토어에 소속되어 있지 않습니다."));
+}
+
+// -------------------- 2. getAllEvents, getEvent 테스트 --------------------
+@Test
+public void testGetAllEventsSuccess() {
+    createTestEvent();
+    createTestEvent();
+
+    List<EventResponseDto> eventList = eventService.getAllEvents();
+
+    assertNotNull(eventList);
+    assertTrue(eventList.size() >= 2);
+    for (EventResponseDto eventResponseDto : eventList) {
+        System.out.println("Event Id: " + eventResponseDto.getId());
+        System.out.println("Streamer Id: " + eventResponseDto.getStreamerStoreId());
+        System.out.println("ItemList: " + eventResponseDto.getEventItemList()); // 여러 건 조회에서는 Item들은 null 반환
+        System.out.println();
     }
-
-
-    // 1-3. 잘못된 ID로 create
-    @Test
-    public void testCreateEventFailure_ItemNotBelongToStore() {
-        String uniqueSuffix = UUID.randomUUID().toString().substring(0, 4);
-        Streamer streamer2 = Streamer.builder()
-                .name("스트리머" + uniqueSuffix)
-                .nickName("스트리머" + uniqueSuffix)
-                .phoneNumber("010" + ((int) (Math.random() * 90000000 + 10000000)))
-                .email("streamer2" + uniqueSuffix + "@example.com")
-                .password("password")
-                .build();
-        streamerRepository.save(streamer2);
-
-        Store otherStore = Store.builder()
-                .streamer(streamer2)
-                .storeName("OtherStore" + uniqueSuffix)
-                .address("OtherAddress" + uniqueSuffix)
-                .registrationNumber("OtherReg" + uniqueSuffix)
-                .build();
-        otherStore = storeRepository.save(otherStore);
-
-        Item otherItem = Item.builder()
-                .store(otherStore)
-                .itemName("OtherItem" + uniqueSuffix)
-                .explanation("Other Desc")
-                .price(7000)
-                .remainingQuantity(50)
-                .build();
-        otherItem = itemRepository.save(otherItem);
-
-        List<EventItemRequestDto> eventItemList = new ArrayList<>();
-        // 기존 스토어에 속하지 않는 아이템 사용
-        eventItemList.add(new EventItemRequestDto(otherItem.getId(), 2));
-
-        EventRequestDto requestDto = EventRequestDto.builder()
-                .storeId(testStore.getId())  // 기본 store
-                .numberOfWinners(3)
-                .participantCondition(ParticipantCondition.ALL_USERS.name())
-                .selectionMethod(SelectionMethod.RANDOM_DRAW.name())
-                .startDatetime(LocalDateTime.now().minusMinutes(1))
-                .endDatetime(LocalDateTime.now().plusDays(1))
-                .eventItemList(eventItemList)
-                .build();
-
-        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
-            eventService.createEvent(testStreamer.getId(), requestDto);
-        });
-        assertTrue(exception.getMessage().contains("현재 스토어에 소속되어 있지 않습니다."));
-    }
-
-    // -------------------- 2. getAllEvents, getEvent 테스트 --------------------
-    @Test
-    public void testGetAllEventsSuccess() {
-        createTestEvent();
-        createTestEvent();
-
-        List<EventResponseDto> eventList = eventService.getAllEvents();
-
-        assertNotNull(eventList);
-        assertTrue(eventList.size() >= 2);
-        for (EventResponseDto eventResponseDto : eventList) {
-            System.out.println("Event Id: " + eventResponseDto.getId());
-            System.out.println("Streamer Id: " + eventResponseDto.getStreamerStoreId());
-            System.out.println("ItemList: " + eventResponseDto.getEventItemList()); // 여러 건 조회에서는 Item들은 null 반환
-            System.out.println();
-        }
-    }
+}
 
 //   2-2. 단건 조회
-    @Test
-    public void testGetEventSuccess() {
-        EventResponseDto createdEvent = createTestEvent();
+@Test
+public void testGetEventSuccess() {
+    EventResponseDto createdEvent = createTestEvent();
 
-        EventResponseDto fetchedEvent = eventService.getEvent(createdEvent.getId());
+    EventResponseDto fetchedEvent = eventService.getEvent(createdEvent.getId());
 
-        assertNotNull(fetchedEvent);
-        assertEquals(createdEvent.getId(), fetchedEvent.getId());
-        assertNotNull(fetchedEvent.getEventItemList());
-        assertFalse(fetchedEvent.getEventItemList().isEmpty());
-        // 콘솔 출력 (디버깅용)
-        System.out.println("Event ID : " + fetchedEvent.getId());
-    }
+    assertNotNull(fetchedEvent);
+    assertEquals(createdEvent.getId(), fetchedEvent.getId());
+    assertNotNull(fetchedEvent.getEventItemList());
+    assertFalse(fetchedEvent.getEventItemList().isEmpty());
+    // 콘솔 출력 (디버깅용)
+    System.out.println("Event ID : " + fetchedEvent.getId());
+}
 
 //  2-3. 존재하지 않는 조회
-    @Test
-    public void testGetEventFailure_NotFound() {
-        // Act & Assert
-        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
-            eventService.getEvent(-999);
-        });
-        assertTrue(exception.getMessage().contains("해당 이벤트를 찾을 수 없습니다."));
+@Test
+public void testGetEventFailure_NotFound() {
+    // Act & Assert
+    Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+        eventService.getEvent(-999);
+    });
+    assertTrue(exception.getMessage().contains("해당 이벤트를 찾을 수 없습니다."));
+}
+
+// -------------------- 3. closeEvent 테스트 --------------------
+@Test
+public void testCloseEventSuccess() {
+    EventResponseDto createdEvent = createTestEvent();
+    Event event = eventRepository.findById(createdEvent.getId()).orElseThrow();
+
+    int totalApplicants = 10;
+    for (int i = 0; i < totalApplicants; i++) {
+        String uniqueSuffix = UUID.randomUUID().toString().substring(0, 3);
+        EventApplicant applicant = EventApplicant.builder()
+                .event(event)
+                .email("applicant" + uniqueSuffix + "@example.com")
+                .applicantName("지원자" + uniqueSuffix)
+                .applicantPassword("password")
+                .deliveryAddress("Address" + uniqueSuffix)
+                .applicantStatus(ApplicantStatus.WAITING)
+                .build();
+        eventApplicantRepository.save(applicant);
     }
 
-    // -------------------- 3. closeEvent 테스트 --------------------
-    @Test
-    public void testCloseEventSuccess() {
-        EventResponseDto createdEvent = createTestEvent();
-        Event event = eventRepository.findById(createdEvent.getId()).orElseThrow();
+    EventClosingResponseDto closingResponse = eventService.closeEvent(testStreamer.getId(), createdEvent.getId());
 
-        int totalApplicants = 10;
-        for (int i = 0; i < totalApplicants; i++) {
-            String uniqueSuffix = UUID.randomUUID().toString().substring(0, 3);
-            EventApplicant applicant = EventApplicant.builder()
-                    .event(event)
-                    .email("applicant" + uniqueSuffix + "@example.com")
-                    .applicantName("지원자" + uniqueSuffix)
-                    .applicantPassword("password")
-                    .deliveryAddress("Address" + uniqueSuffix)
-                    .applicantStatus(ApplicantStatus.WAITING)
-                    .build();
-            eventApplicantRepository.save(applicant);
+    assertNotNull(closingResponse);
+    assertEquals(createdEvent.getId(), closingResponse.getId());
+    assertTrue(closingResponse.getIsCompleted());
+    assertNotNull(closingResponse.getEventApplicants());
+    assertEquals(totalApplicants, closingResponse.getEventApplicants().size());
+
+    // 당첨자/낙첨자 상태 검증
+    List<EventApplicant> applicants = eventApplicantRepository.findByEvent(event);
+    int winnerCount = 0;
+    for (EventApplicant a : applicants) {
+        assertTrue(a.getApplicantStatus() == ApplicantStatus.WINNER ||
+                a.getApplicantStatus() == ApplicantStatus.LOSER);
+        if (a.getApplicantStatus() == ApplicantStatus.WINNER) {
+            winnerCount++;
         }
-
-        EventClosingResponseDto closingResponse = eventService.closeEvent(testStreamer.getId(), createdEvent.getId());
-
-        assertNotNull(closingResponse);
-        assertEquals(createdEvent.getId(), closingResponse.getId());
-        assertTrue(closingResponse.getIsCompleted());
-        assertNotNull(closingResponse.getEventApplicants());
-        assertEquals(totalApplicants, closingResponse.getEventApplicants().size());
-
-        // 당첨자/낙첨자 상태 검증
-        List<EventApplicant> applicants = eventApplicantRepository.findByEvent(event);
-        int winnerCount = 0;
-        for (EventApplicant a : applicants) {
-            assertTrue(a.getApplicantStatus() == ApplicantStatus.WINNER ||
-                    a.getApplicantStatus() == ApplicantStatus.LOSER);
-            if (a.getApplicantStatus() == ApplicantStatus.WINNER) {
-                winnerCount++;
-            }
-        }
-        assertEquals(createdEvent.getNumberOfWinners(), winnerCount);
     }
+    assertEquals(createdEvent.getNumberOfWinners(), winnerCount);
+}
 
 //    3-2.이벤트에 응모자가 없는 경우
-    @Test
-    public void testCloseEventFailure_NoApplicants() {
-        EventResponseDto createdEvent = createTestEvent();
+@Test
+public void testCloseEventFailure_NoApplicants() {
+    EventResponseDto createdEvent = createTestEvent();
 
-        Exception exception = assertThrows(IllegalStateException.class, () -> {
-            eventService.closeEvent(testStreamer.getId(), createdEvent.getId());
-        });
+    Exception exception = assertThrows(IllegalStateException.class, () -> {
+        eventService.closeEvent(testStreamer.getId(), createdEvent.getId());
+    });
 
-        assertTrue(exception.getMessage().contains("응모자가 없습니다."));
-    }
+    assertTrue(exception.getMessage().contains("응모자가 없습니다."));
+}
 
-    // -------------------- 4. cancelEvent 테스트 --------------------
-    @Test
-    public void testCancelEventSuccess() {
-        List<EventItemRequestDto> eventItemList = new ArrayList<>();
-        eventItemList.add(new EventItemRequestDto(testItem1.getId(), 2)); // 차감될 재고:2*당첨자수
-        EventRequestDto requestDto = EventRequestDto.builder()
-                .storeId(testStore.getId())
-                .numberOfWinners(3)
-                .participantCondition(ParticipantCondition.ALL_USERS.name())
-                .selectionMethod(SelectionMethod.RANDOM_DRAW.name())
-                .startDatetime(LocalDateTime.now().minusMinutes(1))
-                .endDatetime(LocalDateTime.now().plusDays(1))
-                .eventItemList(eventItemList)
-                .build();
-        EventResponseDto createdEvent = eventService.createEvent(testStreamer.getId(), requestDto);
+// -------------------- 4. cancelEvent 테스트 --------------------
+@Test
+public void testCancelEventSuccess() {
+    List<EventItemRequestDto> eventItemList = new ArrayList<>();
+    eventItemList.add(new EventItemRequestDto(testItem1.getId(), 2)); // 차감될 재고:2*당첨자수
+    EventRequestDto requestDto = EventRequestDto.builder()
+            .storeId(testStore.getId())
+            .numberOfWinners(3)
+            .participantCondition(ParticipantCondition.ALL_USERS.name())
+            .selectionMethod(SelectionMethod.RANDOM_DRAW.name())
+            .startDatetime(LocalDateTime.now().minusMinutes(1))
+            .endDatetime(LocalDateTime.now().plusDays(1))
+            .eventItemList(eventItemList)
+            .build();
+    EventResponseDto createdEvent = eventService.createEvent(testStreamer.getId(), requestDto);
 
-        eventService.cancelEvent(testStreamer.getId(), createdEvent.getId());
+    eventService.cancelEvent(testStreamer.getId(), createdEvent.getId());
 
-        Event cancelledEvent = eventRepository.findById(createdEvent.getId()).orElseThrow();
-        assertTrue(cancelledEvent.getIsDeleted());
+    Event cancelledEvent = eventRepository.findById(createdEvent.getId()).orElseThrow();
+    assertTrue(cancelledEvent.getIsDeleted());
 
-        // 재고 복구 여부 확인 : 차감된 재고 만큼 복구되어야 함.
-        Item item1Reload = itemRepository.findById(testItem1.getId()).orElseThrow();
-        // 원래 잔여수량 100 - (2*3) 차감 후 cancel 에서 복구되므로 다시 100이어야 함.
-        assertEquals(100, item1Reload.getRemainingQuantity());
-    }
+    // 재고 복구 여부 확인 : 차감된 재고 만큼 복구되어야 함.
+    Item item1Reload = itemRepository.findById(testItem1.getId()).orElseThrow();
+    // 원래 잔여수량 100 - (2*3) 차감 후 cancel 에서 복구되므로 다시 100이어야 함.
+    assertEquals(100, item1Reload.getRemainingQuantity());
+}
 
 //4-2. 마감된 이벤트 취소 시도
 @Test
@@ -369,83 +375,83 @@ public void testCancelEventFailure_AlreadyCompleted() {
     assertTrue(ex.getMessage().contains("이미 마감된 이벤트는 취소할 수 없습니다."));
 }
 
-    // -------------------- 5. confirmReceipt 테스트 --------------------
-    @Test
-    public void testConfirmReceiptSuccess() {
-        EventResponseDto createdEvent = createTestEvent();
-        Event event = eventRepository.findById(createdEvent.getId()).orElseThrow();
+// -------------------- 5. confirmReceipt 테스트 --------------------
+@Test
+public void testConfirmReceiptSuccess() {
+    EventResponseDto createdEvent = createTestEvent();
+    Event event = eventRepository.findById(createdEvent.getId()).orElseThrow();
 
-        String uniqueSuffix = UUID.randomUUID().toString().substring(0, 3);
-        EventApplicant applicant = EventApplicant.builder()
-                .event(event)
-                .email("confirm" + uniqueSuffix + "@example.com")
-                .applicantName("지원자" + uniqueSuffix)
-                .applicantPassword("password")
-                .deliveryAddress("기존주소" + uniqueSuffix)
-                .applicantStatus(ApplicantStatus.WINNER) // WINNER 상태 세팅
-                .build();
-        EventApplicant savedApplicant = eventApplicantRepository.save(applicant);
+    String uniqueSuffix = UUID.randomUUID().toString().substring(0, 3);
+    EventApplicant applicant = EventApplicant.builder()
+            .event(event)
+            .email("confirm" + uniqueSuffix + "@example.com")
+            .applicantName("지원자" + uniqueSuffix)
+            .applicantPassword("password")
+            .deliveryAddress("기존주소" + uniqueSuffix)
+            .applicantStatus(ApplicantStatus.WINNER) // WINNER 상태 세팅
+            .build();
+    EventApplicant savedApplicant = eventApplicantRepository.save(applicant);
 
-        // “수령 확정” 요청 DTO 준비
-        EventApplicantRequestDto updateRequest = EventApplicantRequestDto.builder()
-                .applicantName("변경된이름")
-                .deliveryAddress("변경된주소")
-                .build();
+    // “수령 확정” 요청 DTO 준비
+    EventApplicantRequestDto updateRequest = EventApplicantRequestDto.builder()
+            .applicantName("변경된이름")
+            .deliveryAddress("변경된주소")
+            .build();
 
-        EventApplicantResponseDto updatedResponse = eventApplicantService.confirmReceipt(savedApplicant.getId(), updateRequest);
+    EventApplicantResponseDto updatedResponse = eventApplicantService.confirmReceipt(savedApplicant.getId(), updateRequest);
 
-        assertNotNull(updatedResponse);
-        assertEquals(savedApplicant.getId(), updatedResponse.getId());
-        assertEquals("변경된이름", updatedResponse.getApplicantName());
-        assertEquals("변경된주소", updatedResponse.getDeliveryAddress());
-        assertEquals(ApplicantStatus.CONFIRMED, updatedResponse.getApplicantStatus());
-    }
+    assertNotNull(updatedResponse);
+    assertEquals(savedApplicant.getId(), updatedResponse.getId());
+    assertEquals("변경된이름", updatedResponse.getApplicantName());
+    assertEquals("변경된주소", updatedResponse.getDeliveryAddress());
+    assertEquals(ApplicantStatus.CONFIRMED, updatedResponse.getApplicantStatus());
+}
 
 //    5-2.당첨자 아닌데 수령 확정 시도
-    @Test
-    public void testConfirmReceiptFailure_NotWinner() {
-        EventResponseDto createdEvent = createTestEvent();
-        Event event = eventRepository.findById(createdEvent.getId()).orElseThrow();
-        String uniqueSuffix = UUID.randomUUID().toString().substring(0, 3);
-        EventApplicant applicant = EventApplicant.builder()
-                .event(event)
-                .email("nonWinner" + uniqueSuffix + "@example.com")
-                .applicantName("지원자" + uniqueSuffix)
-                .applicantPassword("password")
-                .deliveryAddress("주소" + uniqueSuffix)
-                .applicantStatus(ApplicantStatus.WAITING) // WINNER가 아님
-                .build();
-        EventApplicant savedApplicant = eventApplicantRepository.save(applicant);
+@Test
+public void testConfirmReceiptFailure_NotWinner() {
+    EventResponseDto createdEvent = createTestEvent();
+    Event event = eventRepository.findById(createdEvent.getId()).orElseThrow();
+    String uniqueSuffix = UUID.randomUUID().toString().substring(0, 3);
+    EventApplicant applicant = EventApplicant.builder()
+            .event(event)
+            .email("nonWinner" + uniqueSuffix + "@example.com")
+            .applicantName("지원자" + uniqueSuffix)
+            .applicantPassword("password")
+            .deliveryAddress("주소" + uniqueSuffix)
+            .applicantStatus(ApplicantStatus.WAITING) // WINNER가 아님
+            .build();
+    EventApplicant savedApplicant = eventApplicantRepository.save(applicant);
 
-        EventApplicantRequestDto updateRequest = EventApplicantRequestDto.builder()
-                .applicantName("이름변경")
-                .deliveryAddress("주소변경")
-                .build();
+    EventApplicantRequestDto updateRequest = EventApplicantRequestDto.builder()
+            .applicantName("이름변경")
+            .deliveryAddress("주소변경")
+            .build();
 
-        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
-            eventApplicantService.confirmReceipt(savedApplicant.getId(), updateRequest);
-        });
-        assertTrue(exception.getMessage().contains("당첨(WINNER) 상태가 아닌 유저의 수령 확정은 불가능합니다."));
-    }
+    Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+        eventApplicantService.confirmReceipt(savedApplicant.getId(), updateRequest);
+    });
+    assertTrue(exception.getMessage().contains("당첨(WINNER) 상태가 아닌 유저의 수령 확정은 불가능합니다."));
+}
 
 
-    // 헬퍼 메서드: 테스트 이벤트 생성
-    private EventResponseDto createTestEvent() {
-        List<EventItemRequestDto> eventItemList = new ArrayList<>();
-        eventItemList.add(new EventItemRequestDto(testItem1.getId(), 10));
-        eventItemList.add(new EventItemRequestDto(testItem2.getId(), 3));
+// 헬퍼 메서드: 테스트 이벤트 생성
+private EventResponseDto createTestEvent() {
+    List<EventItemRequestDto> eventItemList = new ArrayList<>();
+    eventItemList.add(new EventItemRequestDto(testItem1.getId(), 10));
+    eventItemList.add(new EventItemRequestDto(testItem2.getId(), 3));
 
-        EventRequestDto eventRequestDto = EventRequestDto.builder()
-                .storeId(testStore.getId())
-                .numberOfWinners(5)
-                .participantCondition(ParticipantCondition.ALL_USERS.name())
-                .selectionMethod(SelectionMethod.RANDOM_DRAW.name())
-                .startDatetime(LocalDateTime.now().minusMinutes(1))
-                .endDatetime(LocalDateTime.now().plusDays(1))
-                .eventItemList(eventItemList)
-                .build();
+    EventRequestDto eventRequestDto = EventRequestDto.builder()
+            .storeId(testStore.getId())
+            .numberOfWinners(5)
+            .participantCondition(ParticipantCondition.ALL_USERS.name())
+            .selectionMethod(SelectionMethod.RANDOM_DRAW.name())
+            .startDatetime(LocalDateTime.now().minusMinutes(1))
+            .endDatetime(LocalDateTime.now().plusDays(1))
+            .eventItemList(eventItemList)
+            .build();
 
-        return eventService.createEvent(testStreamer.getId(), eventRequestDto);
-    }
+    return eventService.createEvent(testStreamer.getId(), eventRequestDto);
+}
 
 }


### PR DESCRIPTION
## 목적 🎯 
Event관련 성공/실패 유닛테스트 구현
Event에서 반환 로직 보강

## 변경점 ✔️ 
동시성 이슈 해결(비관락)
유닛 테스트 구현 및 디버깅(다 통과)
이벤트 서비스 반환 로직 구현(이벤트 일부만 당첨되고 반환 → Item 잔여 수량으로 되돌리기)

## 리뷰어에게 🙇 
일단 유닛테스트는 다 돌아 갑니다. 양이 너무 많으므로
EventService와 EventApplicantService 로직을 전반적으로 봐주세용.