### PR TITLE
🚑  fix: JwtFilter whitelist URI add

### DIFF
--- a/src/main/java/excluz/excluz/auth/config/SecurityConfig.java
+++ b/src/main/java/excluz/excluz/auth/config/SecurityConfig.java
@@ -40,7 +40,8 @@ public class SecurityConfig {
 					"/api/v1/streamers/login", // 판매자 로그인
 					"/api/v1/users/signup", // 일반 유저 회원가입
 					"/api/v1/streamers/signup", // 판매자 회원가입
-					"/api/v1/events/applicants" // 이벤트 응모 및 조회(단, @RequestParam 코드가 맞을 때)
+					"/api/v1/events/applicants",// 이벤트 응모 및 조회(단, @RequestParam 코드가 맞을 때)
+					"/api/v1/users/*"
 					).permitAll()
 				.requestMatchers("/api/v1/admin/**").hasRole("ADMIN") // 관리자
 				.requestMatchers("/api/v1/users/**").hasRole("CUSTOMER") // 일반 회원

--- a/src/main/java/excluz/excluz/auth/filter/JwtFilter.java
+++ b/src/main/java/excluz/excluz/auth/filter/JwtFilter.java
@@ -27,15 +27,13 @@ public class JwtFilter implements Filter {
 
 	private final JwtUtil jwtUtil;
 
-	private static final String[] SIGN_UP_URI = {
+	private static final String[] WHITE_LIST = {
 		"/api/v1/users/signup",
 		"/api/v1/streamers/signup",
-		"/api/v1/events/applicants"
-	};
-
-	private static final String[] SIGN_IN_URI = {
+		"/api/v1/events/applicants",
 		"/api/v1/users/login",
-		"/api/v1/streamers/login"
+		"/api/v1/streamers/login",
+		"/api/v1/users/*"
 	};
 
 	@Override
@@ -46,7 +44,7 @@ public class JwtFilter implements Filter {
 		HttpServletResponse httpResponse = (HttpServletResponse) response;
 		String requestURI = httpRequest.getRequestURI();
 
-		if (isSignUpURI(requestURI) || isSignInURI(requestURI)) {
+		if (whiteListURI(requestURI)) {
 			chain.doFilter(request, response);
 			return;
 		}
@@ -76,14 +74,7 @@ public class JwtFilter implements Filter {
 	}
 
 	// requestURI가 회원가입 URI인지 확인
-	public boolean isSignUpURI(String requestURI) {
-		return PatternMatchUtils.simpleMatch(SIGN_UP_URI, requestURI);
+	public boolean whiteListURI(String requestURI) {
+		return PatternMatchUtils.simpleMatch(WHITE_LIST, requestURI);
 	}
-
-	// requestURI가 로그인 URI인지 확인
-	public boolean isSignInURI(String requestURI) {
-		return PatternMatchUtils.simpleMatch(SIGN_IN_URI, requestURI);
-	}
-
-
 }


### PR DESCRIPTION
## 목적
권한이 필요없는URL 화이트 리스트에 URL 추가

## 변경점
JwtFilter whiteList 로 통합

URL 추가
"/api/v1/streamers/{streamerId}",
"/api/v1/items/{itemsId}",
"/api/v1/stores?storeName=&page=&size=",
"/api/v1/stores/*/?page=&size=",
"/api/v1/streamers?nickName=&page=&size="