### PR TITLE
🚑fix:Functions hotfix

### DIFF
--- a/src/main/java/excluz/excluz/common/entity/Store.java
+++ b/src/main/java/excluz/excluz/common/entity/Store.java
@@ -2,11 +2,12 @@ package excluz.excluz.common.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToOne;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.Builder;
 import lombok.Getter;
@@ -22,7 +23,7 @@ public class Store extends BaseEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Integer id;
 
-	@OneToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "streamer_id")
 	private Streamer streamer;
 

--- a/src/main/java/excluz/excluz/common/entity/Store.java
+++ b/src/main/java/excluz/excluz/common/entity/Store.java
@@ -32,7 +32,7 @@ public class Store extends BaseEntity {
 	@Column(length = 30, unique = true, nullable = false)
 	private String storeName;
 
-	@Column(length = 30, unique = true, nullable = false)
+	@Column(length = 30, nullable = false)
 	private String registrationNumber;
 
 	@Column(name = "is_deleted")

--- a/src/main/java/excluz/excluz/common/exception/ConflictException.java
+++ b/src/main/java/excluz/excluz/common/exception/ConflictException.java
@@ -1,0 +1,9 @@
+package excluz.excluz.common.exception;
+
+import excluz.excluz.common.exception.error.ErrorCode;
+
+public class ConflictException extends CustomRuntimeException {
+	public ConflictException(ErrorCode errorCode) {
+		super(errorCode);
+	}
+}

--- a/src/main/java/excluz/excluz/common/exception/error/ErrorCode.java
+++ b/src/main/java/excluz/excluz/common/exception/error/ErrorCode.java
@@ -30,6 +30,7 @@ public enum ErrorCode {
 	//스토어 관련 예외 코드
 	STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "스토어 정보를 찾을 수 없습니다."),
 	STORE_NOT_MATCH(HttpStatus.BAD_REQUEST, "스토어에 대한 권한이 없습니다"),
+	DUPLICATE_REGISTRATION_NUMBER(HttpStatus.CONFLICT, "다른 스토어와 중복되는 사업자 등록번호입니다."),
 
 	// 포인트 관련 예외 코드
 	POINT_NOT_FOUND(HttpStatus.NOT_FOUND, "포인트를 충전해주세요."),

--- a/src/main/java/excluz/excluz/common/exception/error/ErrorCode.java
+++ b/src/main/java/excluz/excluz/common/exception/error/ErrorCode.java
@@ -31,6 +31,7 @@ public enum ErrorCode {
 	STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "스토어 정보를 찾을 수 없습니다."),
 	STORE_NOT_MATCH(HttpStatus.BAD_REQUEST, "스토어에 대한 권한이 없습니다"),
 	DUPLICATE_REGISTRATION_NUMBER(HttpStatus.CONFLICT, "다른 스토어와 중복되는 사업자 등록번호입니다."),
+	STORE_ALREADY_EXIST(HttpStatus.CONFLICT, "운영중인 스토어가 이미 존재합니다."),
 
 	// 포인트 관련 예외 코드
 	POINT_NOT_FOUND(HttpStatus.NOT_FOUND, "포인트를 충전해주세요."),

--- a/src/main/java/excluz/excluz/domain/store/item/controller/ItemV1Controller.java
+++ b/src/main/java/excluz/excluz/domain/store/item/controller/ItemV1Controller.java
@@ -1,6 +1,5 @@
 package excluz.excluz.domain.store.item.controller;
 
-import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -10,6 +9,7 @@ import excluz.excluz.auth.util.SecurityContextUtil;
 import excluz.excluz.domain.store.item.dto.request.ItemCreateRequestDto;
 import excluz.excluz.domain.store.item.dto.request.ItemUpdateRequestDto;
 import excluz.excluz.domain.store.item.dto.response.ItemResponseDto;
+import excluz.excluz.domain.store.item.dto.response.GetItemListResponseDto;
 import excluz.excluz.domain.store.item.service.ItemService;
 
 import jakarta.validation.Valid;
@@ -66,15 +66,15 @@ public class ItemV1Controller {
 	}
 
 	@GetMapping()
-	public ResponseEntity<Page<ItemResponseDto>> getItemList(
+	public ResponseEntity<GetItemListResponseDto> getItemList(
 		@RequestParam(defaultValue = "0") int page,
 		@RequestParam(defaultValue = "10") int size,
-		@RequestParam(required = false, defaultValue = "0") Integer minPrice,
-		@RequestParam(required = false, defaultValue = "-1") Integer maxPrice,
+		@RequestParam(defaultValue = "0") Integer minPrice,
+		@RequestParam(defaultValue = "-1") Integer maxPrice,
 		@RequestParam(required = false) String itemName
 	) {
-		Page<ItemResponseDto> itemResponseDtoList = itemService.getItemList(page, size, minPrice, maxPrice, itemName);
+		GetItemListResponseDto responseDto = itemService.getItemList(page, size, Math.max(minPrice, 0), maxPrice, itemName);
 
-		return new ResponseEntity<>(itemResponseDtoList, HttpStatus.OK);
+		return new ResponseEntity<>(responseDto, HttpStatus.OK);
 	}
 }

--- a/src/main/java/excluz/excluz/domain/store/item/controller/ItemV1Controller.java
+++ b/src/main/java/excluz/excluz/domain/store/item/controller/ItemV1Controller.java
@@ -67,7 +67,7 @@ public class ItemV1Controller {
 
 	@GetMapping()
 	public ResponseEntity<Page<ItemResponseDto>> getItemList(
-		@RequestParam(defaultValue = "1") int page,
+		@RequestParam(defaultValue = "0") int page,
 		@RequestParam(defaultValue = "10") int size,
 		@RequestParam(required = false, defaultValue = "0") Integer minPrice,
 		@RequestParam(required = false, defaultValue = "-1") Integer maxPrice,

--- a/src/main/java/excluz/excluz/domain/store/item/dto/response/GetItemListResponseDto.java
+++ b/src/main/java/excluz/excluz/domain/store/item/dto/response/GetItemListResponseDto.java
@@ -1,0 +1,21 @@
+package excluz.excluz.domain.store.item.dto.response;
+
+import org.springframework.data.domain.Page;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class GetItemListResponseDto {
+
+	private Integer minPrice;
+	private Integer maxPrice;
+	private Page<ItemResponseDto> responseDtoPage;
+
+	public GetItemListResponseDto(Integer minPrice, Integer maxPrice, Page<ItemResponseDto> responseDtoPage) {
+		this.minPrice=minPrice;
+		this.maxPrice=maxPrice;
+		this.responseDtoPage=responseDtoPage;
+	}
+}

--- a/src/main/java/excluz/excluz/domain/store/item/service/ItemService.java
+++ b/src/main/java/excluz/excluz/domain/store/item/service/ItemService.java
@@ -15,6 +15,7 @@ import excluz.excluz.common.exception.NotFoundException;
 import excluz.excluz.common.exception.error.ErrorCode;
 import excluz.excluz.domain.store.item.dto.request.ItemCreateRequestDto;
 import excluz.excluz.domain.store.item.dto.request.ItemUpdateRequestDto;
+import excluz.excluz.domain.store.item.dto.response.GetItemListResponseDto;
 import excluz.excluz.domain.store.item.dto.response.ItemResponseDto;
 import excluz.excluz.domain.store.item.repository.ItemRepository;
 import excluz.excluz.domain.store.store.repository.StoreRepository;
@@ -80,7 +81,7 @@ public class ItemService {
 	}
 
 	@Transactional(readOnly = true)
-	public Page<ItemResponseDto> getItemList(int page, int size, Integer minPrice, Integer maxPrice, String itemName) {
+	public GetItemListResponseDto getItemList(int page, int size, Integer minPrice, Integer maxPrice, String itemName) {
 
 		Pageable pageable = PageRequest.of(Math.max(page, 0), size);
 		int newMinPrice=minPrice, newMaxPrice=maxPrice;
@@ -93,12 +94,12 @@ public class ItemService {
 		}
 		else if (maxPrice <= minPrice) {
 			newMaxPrice = highestPrice.orElse(minPrice + 1);
-			newMinPrice = maxPrice;
 		}
 
 		Page<Item> items = itemRepository.findByPriceWithItemName(pageable, newMinPrice, newMaxPrice, itemName);
+		Page<ItemResponseDto> responseDtoPage = items.map(ItemResponseDto::from);
 
-		return items.map(ItemResponseDto::from);
+		return new GetItemListResponseDto(newMinPrice, newMaxPrice, responseDtoPage);
 	}
 
 	// 삭제 되지 않은 아이템만 조회하는 메서드

--- a/src/main/java/excluz/excluz/domain/store/item/service/ItemService.java
+++ b/src/main/java/excluz/excluz/domain/store/item/service/ItemService.java
@@ -82,7 +82,7 @@ public class ItemService {
 	@Transactional(readOnly = true)
 	public Page<ItemResponseDto> getItemList(int page, int size, Integer minPrice, Integer maxPrice, String itemName) {
 
-		Pageable pageable = PageRequest.of(Math.max(page - 1, 0), size);
+		Pageable pageable = PageRequest.of(Math.max(page, 0), size);
 		int newMinPrice=minPrice, newMaxPrice=maxPrice;
 		Optional<Integer> highestPrice = itemRepository.findHighestItemPrice();
 

--- a/src/main/java/excluz/excluz/domain/store/store/controller/StoreV1Controller.java
+++ b/src/main/java/excluz/excluz/domain/store/store/controller/StoreV1Controller.java
@@ -44,15 +44,14 @@ public class StoreV1Controller {
 		return new ResponseEntity<>(responseDto, HttpStatus.CREATED);
 	}
 
-	@DeleteMapping("/{storeId}/soft")
+	@DeleteMapping("/my-store/soft")
 	@PreAuthorize("hasRole('STREAMER')")
 	public ResponseEntity<Void> deleteStore(
-		@PathVariable Integer storeId,
 		@Valid @RequestBody StoreDeleteRequestDto deleteRequestDto
 	) {
 		Integer streamerId = SecurityContextUtil.getUserOrStreamerId();
 
-		storeService.deleteStore(deleteRequestDto, streamerId, storeId);
+		storeService.deleteStore(deleteRequestDto, streamerId);
 
 		return new ResponseEntity<>(HttpStatus.NO_CONTENT);
 	}

--- a/src/main/java/excluz/excluz/domain/store/store/controller/StoreV1Controller.java
+++ b/src/main/java/excluz/excluz/domain/store/store/controller/StoreV1Controller.java
@@ -73,7 +73,7 @@ public class StoreV1Controller {
 	@GetMapping()
 	public ResponseEntity<Page<StoreNameResponseDto>> getStoreList(
 		@RequestParam(required = false) String storeName,
-		@RequestParam(defaultValue = "1") int page,
+		@RequestParam(defaultValue = "0") int page,
 		@RequestParam(defaultValue = "10") int size
 	) {
 		Page<StoreNameResponseDto> responseDtoList = storeService.getStoreList(storeName, page, size);
@@ -84,7 +84,7 @@ public class StoreV1Controller {
 	@GetMapping("/{storeId}")
 	public ResponseEntity<StoreDetailResponseDto> getStoreById(
 		@PathVariable Integer storeId,
-		@RequestParam(defaultValue = "1") int page,
+		@RequestParam(defaultValue = "0") int page,
 		@RequestParam(defaultValue = "10") int size
 	) {
 		StoreDetailResponseDto responseDto = storeService.getStoreById(storeId, page, size);
@@ -94,7 +94,7 @@ public class StoreV1Controller {
 
 	@GetMapping("/my-store")
 	public ResponseEntity<StoreDetailResponseDto> getOwnedStore(
-		@RequestParam(defaultValue = "1") int page,
+		@RequestParam(defaultValue = "0") int page,
 		@RequestParam(defaultValue = "10") int size
 	) {
 		Integer streamerId = SecurityContextUtil.getUserOrStreamerId();

--- a/src/main/java/excluz/excluz/domain/store/store/repository/StoreRepository.java
+++ b/src/main/java/excluz/excluz/domain/store/store/repository/StoreRepository.java
@@ -24,4 +24,9 @@ public interface StoreRepository extends JpaRepository<Store, Integer> {
 		"AND s.isDeleted=false " +
 		"ORDER BY s.id DESC")
 	Page<Store> findByStoreName(Pageable pageable, @Param("storeName") String storeName);
+
+	@Query("SELECT s FROM Store s " +
+		"WHERE (s.registrationNumber LIKE :registrationNumber) " +
+		"AND s.isDeleted = false")
+	Optional<Store> findByRegistrationNumber(@Param("registrationNumber") String registrationNumber);
 }

--- a/src/main/java/excluz/excluz/domain/store/store/repository/StoreRepository.java
+++ b/src/main/java/excluz/excluz/domain/store/store/repository/StoreRepository.java
@@ -13,7 +13,7 @@ import excluz.excluz.common.entity.Streamer;
 
 public interface StoreRepository extends JpaRepository<Store, Integer> {
 
-	@Query("SELECT s FROM Store s JOIN FETCH s.streamer WHERE s.streamer.id = :streamerId")
+	@Query("SELECT s FROM Store s JOIN FETCH s.streamer WHERE s.streamer.id = :streamerId AND s.isDeleted = false")
 	Optional<Store> findStoreWithStreamer(@Param("streamerId") Integer streamerId);
 
 	@Query("SELECT s.streamer FROM Store s WHERE s.id = :storeId")
@@ -21,7 +21,7 @@ public interface StoreRepository extends JpaRepository<Store, Integer> {
 
 	@Query("SELECT s FROM Store s " +
 		"WHERE (:storeName IS NULL OR s.storeName LIKE CONCAT('%', :storeName, '%')) " +
-		"AND s.isDeleted=false " +
+		"AND s.isDeleted = false " +
 		"ORDER BY s.id DESC")
 	Page<Store> findByStoreName(Pageable pageable, @Param("storeName") String storeName);
 
@@ -29,4 +29,9 @@ public interface StoreRepository extends JpaRepository<Store, Integer> {
 		"WHERE (s.registrationNumber LIKE :registrationNumber) " +
 		"AND s.isDeleted = false")
 	Optional<Store> findByRegistrationNumber(@Param("registrationNumber") String registrationNumber);
+
+	@Query("SELECT s FROM Store s " +
+		"WHERE (s.streamer.id = :streamerId) " +
+		"AND s.isDeleted = false")
+	Optional<Store> findStoreByStreamerIdAndNotDeleted(@Param("streamerId") Integer streamerId);
 }

--- a/src/main/java/excluz/excluz/domain/store/store/service/StoreService.java
+++ b/src/main/java/excluz/excluz/domain/store/store/service/StoreService.java
@@ -1,6 +1,7 @@
 package excluz.excluz.domain.store.store.service;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -13,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 import excluz.excluz.common.entity.Item;
 import excluz.excluz.common.entity.Store;
 import excluz.excluz.common.entity.Streamer;
+import excluz.excluz.common.exception.ConflictException;
 import excluz.excluz.common.exception.ForbiddenException;
 import excluz.excluz.common.exception.NotFoundException;
 import excluz.excluz.common.exception.error.ErrorCode;
@@ -41,6 +43,9 @@ public class StoreService {
 	@Transactional
 	public StoreResponseDto createStore(StoreRequestDto storeRequestDto, Integer streamerId) {
 		Streamer streamer = getStreamerByIdAndNotDeleted(streamerId);
+
+		// 삭제 되지 않은 가게 중 중복된 사업자 등록 번호가 있을경우 예외 처리
+		isDuplicatedRegistrationNumber(storeRequestDto.getRegistrationNumber());
 
 		Store store = Store.builder()
 			.streamer(streamer)
@@ -78,6 +83,11 @@ public class StoreService {
 		// 스토어 주인 검증 로직
 		if (!store.getStreamer().getId().equals(userId)) {
 			throw new ForbiddenException(ErrorCode.FORBIDDEN_USER_ACCESS);
+		}
+
+		// 삭제 되지 않은 가게 중 중복된 사업자 등록 번호가 있을경우 예외 처리
+		if (requestDto.getRegistrationNumber() != null) {
+			isDuplicatedRegistrationNumber(requestDto.getRegistrationNumber());
 		}
 
 		store.updateStore(requestDto.getAddress(),
@@ -154,5 +164,14 @@ public class StoreService {
 			throw new NotFoundException(ErrorCode.STORE_NOT_FOUND);
 		}
 		return store;
+	}
+
+	// 삭제 되지 않은 가게 중 중복된 사업자 등록 번호가 있을경우 예외 처리
+	private void isDuplicatedRegistrationNumber(String registrationNumber) {
+		Optional<Store> duplicateStore = storeRepository.findByRegistrationNumber(registrationNumber);
+
+		if (duplicateStore.isPresent()) {
+			throw new ConflictException(ErrorCode.DUPLICATE_REGISTRATION_NUMBER);
+		}
 	}
 }

--- a/src/main/java/excluz/excluz/domain/store/store/service/StoreService.java
+++ b/src/main/java/excluz/excluz/domain/store/store/service/StoreService.java
@@ -99,7 +99,7 @@ public class StoreService {
 
 	@Transactional(readOnly = true)
 	public Page<StoreNameResponseDto> getStoreList(String storeName, int page, int size) {
-		Pageable pageable = PageRequest.of(Math.max(0, page - 1), size);
+		Pageable pageable = PageRequest.of(Math.max(0, page), size);
 
 		Page<Store> storeList = storeRepository.findByStoreName(pageable, storeName);
 
@@ -108,7 +108,7 @@ public class StoreService {
 
 	@Transactional(readOnly = true)
 	public StoreDetailResponseDto getStoreById(Integer storeId, int page, int size) {
-		Pageable pageable = PageRequest.of(Math.max(0, page - 1), size);
+		Pageable pageable = PageRequest.of(Math.max(0, page), size);
 		Streamer streamer = storeRepository.findStreamerWithStore(storeId).orElseThrow(
 			() -> new NotFoundException(ErrorCode.USER_NOT_FOUND)
 		);
@@ -124,7 +124,7 @@ public class StoreService {
 
 	@Transactional(readOnly = true)
 	public StoreDetailResponseDto getOwnedStoreById(Integer streamerId, int page, int size) {
-		Pageable pageable = PageRequest.of(Math.max(0, page - 1), size);
+		Pageable pageable = PageRequest.of(Math.max(0, page), size);
 		// 스트리머 삭제 회원 여부 확인
 		Streamer streamer = getStreamerByIdAndNotDeleted(streamerId);
 

--- a/src/main/java/excluz/excluz/domain/store/store/service/StoreService.java
+++ b/src/main/java/excluz/excluz/domain/store/store/service/StoreService.java
@@ -44,6 +44,13 @@ public class StoreService {
 	public StoreResponseDto createStore(StoreRequestDto storeRequestDto, Integer streamerId) {
 		Streamer streamer = getStreamerByIdAndNotDeleted(streamerId);
 
+		// 비즈니스 요구사항: 스트리머:스토어 = 1:1 관계
+		// 운영중인 스토어가 있을 경우 예외처리
+		Optional<Store> activeStore = storeRepository.findStoreByStreamerIdAndNotDeleted(streamerId);
+		if(activeStore.isPresent()){
+			throw new ConflictException(ErrorCode.STORE_ALREADY_EXIST);
+		}
+
 		// 삭제 되지 않은 가게 중 중복된 사업자 등록 번호가 있을경우 예외 처리
 		isDuplicatedRegistrationNumber(storeRequestDto.getRegistrationNumber());
 
@@ -58,20 +65,16 @@ public class StoreService {
 	}
 
 	@Transactional
-	public void deleteStore(StoreDeleteRequestDto deleteRequestDto, Integer streamerId, Integer storeId) {
+	public void deleteStore(StoreDeleteRequestDto deleteRequestDto, Integer streamerId) {
 		Streamer streamer = getStreamerByIdAndNotDeleted(streamerId);
 
 		if (!passwordEncoder.matches(deleteRequestDto.getPassword(), streamer.getPassword())) {
 			throw new BadRequestException(ErrorCode.PASSWORD_MISMATCH);
 		}
 
-		Store store = storeRepository.findById(storeId).orElseThrow(
+		Store store = storeRepository.findStoreWithStreamer(streamerId).orElseThrow(
 			() -> new NotFoundException(ErrorCode.STORE_NOT_FOUND)
 		);
-
-		if (store.isDeleted()) {
-			throw new NotFoundException(ErrorCode.STORE_NOT_FOUND);
-		}
 
 		store.updateIsDeleted(true);
 	}

--- a/src/main/java/excluz/excluz/domain/streamer/controller/StreamerV1Controller.java
+++ b/src/main/java/excluz/excluz/domain/streamer/controller/StreamerV1Controller.java
@@ -74,7 +74,7 @@ public class StreamerV1Controller {
 	@GetMapping()
 	public ResponseEntity<Page<StreamerSummaryResponseDto>> getStreamerList(
 		@RequestParam(required = false) String nickName,
-		@RequestParam(defaultValue = "1") int page,
+		@RequestParam(defaultValue = "0") int page,
 		@RequestParam(defaultValue = "10") int size
 	) {
 		Page<StreamerSummaryResponseDto> responseDtoList = streamerService.getStreamerList(page, size, nickName);

--- a/src/main/java/excluz/excluz/domain/streamer/controller/StreamerV1Controller.java
+++ b/src/main/java/excluz/excluz/domain/streamer/controller/StreamerV1Controller.java
@@ -21,12 +21,12 @@ public class StreamerV1Controller {
 	private final StreamerService streamerService;
 
 	@PostMapping("/signup")
-	public ResponseEntity<Void> streamerSignup(
+	public ResponseEntity<StreamerResponseDto> streamerSignup(
 		@Valid @RequestBody StreamerSignupRequestDto signupRequestDto
 	) {
-		streamerService.streamerSignup(signupRequestDto);
+		StreamerResponseDto responseDto = streamerService.streamerSignup(signupRequestDto);
 
-		return new ResponseEntity<>(HttpStatus.CREATED);
+		return new ResponseEntity<>(responseDto, HttpStatus.CREATED);
 	}
 
 	@PostMapping("/login")

--- a/src/main/java/excluz/excluz/domain/streamer/dto/response/StreamerResponseDto.java
+++ b/src/main/java/excluz/excluz/domain/streamer/dto/response/StreamerResponseDto.java
@@ -9,6 +9,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class StreamerResponseDto {
 
+	private Integer streamerId;
 	private String name;
 	private String nickName;
 	private String phoneNumber;
@@ -16,11 +17,13 @@ public class StreamerResponseDto {
 
 	@Builder
 	public StreamerResponseDto(
+		Integer streamerId,
 		String name,
 		String nickName,
 		String phoneNumber,
 		String email
 	) {
+		this.streamerId=streamerId;
 		this.name=name;
 		this.nickName=nickName;
 		this.phoneNumber=phoneNumber;
@@ -29,6 +32,7 @@ public class StreamerResponseDto {
 
 	public static StreamerResponseDto from(Streamer streamer) {
 		return StreamerResponseDto.builder()
+			.streamerId(streamer.getId())
 			.name(streamer.getName())
 			.nickName(streamer.getNickName())
 			.phoneNumber(streamer.getPhoneNumber())

--- a/src/main/java/excluz/excluz/domain/streamer/service/StreamerService.java
+++ b/src/main/java/excluz/excluz/domain/streamer/service/StreamerService.java
@@ -104,7 +104,7 @@ public class StreamerService {
 
 	@Transactional(readOnly = true)
 	public Page<StreamerSummaryResponseDto> getStreamerList(int page, int size, String nickName) {
-		Pageable pageable = PageRequest.of(Math.max(page - 1, 0), size);
+		Pageable pageable = PageRequest.of(Math.max(page, 0), size);
 
 		Page<Streamer> streamerList = streamerRepository.findByNickName(pageable, nickName);
 

--- a/src/main/java/excluz/excluz/domain/streamer/service/StreamerService.java
+++ b/src/main/java/excluz/excluz/domain/streamer/service/StreamerService.java
@@ -30,7 +30,7 @@ public class StreamerService {
 	private final JwtUtil jwtUtil;
 
 	@Transactional
-	public void streamerSignup(StreamerSignupRequestDto signupRequestDto) {
+	public StreamerResponseDto streamerSignup(StreamerSignupRequestDto signupRequestDto) {
 		if (!signupRequestDto.getPassword().equals(signupRequestDto.getReEnterPassword())) {
 			throw new BadRequestException(ErrorCode.PASSWORD_MISMATCH);
 		}
@@ -45,7 +45,7 @@ public class StreamerService {
 			.password(encodedPassword)
 			.build();
 
-		streamerRepository.save(streamer);
+		return StreamerResponseDto.from(streamerRepository.save(streamer));
 	}
 
 	public StreamerLoginResponseDto streamerLogin(StreamerLoginRequestDto loginRequestDto) {

--- a/src/test/java/excluz/excluz/domain/store/item/service/ItemServiceTest.java
+++ b/src/test/java/excluz/excluz/domain/store/item/service/ItemServiceTest.java
@@ -30,6 +30,7 @@ import excluz.excluz.common.entity.Store;
 import excluz.excluz.common.entity.Streamer;
 import excluz.excluz.common.exception.ForbiddenException;
 import excluz.excluz.common.exception.NotFoundException;
+import excluz.excluz.domain.store.item.dto.response.GetItemListResponseDto;
 import excluz.excluz.domain.store.item.dto.response.ItemResponseDto;
 import excluz.excluz.domain.store.item.repository.ItemRepository;
 import excluz.excluz.domain.store.store.repository.StoreRepository;
@@ -292,7 +293,9 @@ class ItemServiceTest {
 		@DisplayName("success: 일반 케이스 - minPrice와 maxPrice가 정상 범위임")
 		void getItemListStandard() {
 			// given
-			Pageable pageable = PageRequest.of(1, 10);
+			int page = 0;
+			int size = 10;
+			Pageable pageable = PageRequest.of(page, size);
 			when(itemRepository.findHighestItemPrice()).thenReturn(Optional.of(5000));
 			List<Item> itemList = Collections.singletonList(SharedData.ITEM2);
 			Page<Item> itemPage = new PageImpl<>(itemList, pageable, itemList.size());
@@ -303,14 +306,17 @@ class ItemServiceTest {
 				given(ItemResponseDto.from(any(Item.class))).willReturn(SharedData.ITEM_RESPONSE_DTO);
 
 				// when
-				Page<ItemResponseDto> actualResult = itemService.getItemList(2, 10, 1000, 5000, SharedData.ITEM_NAME2);
+				GetItemListResponseDto actualResult = itemService.getItemList(page, size, 1000, 5000, SharedData.ITEM_NAME2);
 
 				// then
 				verify(itemRepository).findHighestItemPrice();
 				verify(itemRepository).findByPriceWithItemName(eq(pageable), anyInt(), anyInt(), anyString());
 
 				assertThat(actualResult).isNotNull();
-				ItemResponseDto dto = actualResult.getContent().get(0);
+				assertThat(actualResult.getMaxPrice()).isEqualTo(5000);
+				assertThat(actualResult.getMinPrice()).isEqualTo(1000);
+
+				ItemResponseDto dto = actualResult.getResponseDtoPage().getContent().get(0);
 				assertThat(dto.getItemName()).isEqualTo(SharedData.ITEM2.getItemName());
 				assertThat(dto.getRemainingQuantity()).isEqualTo(SharedData.ITEM2.getRemainingQuantity());
 				assertThat(dto.getPrice()).isEqualTo(SharedData.ITEM2.getPrice());
@@ -319,10 +325,12 @@ class ItemServiceTest {
 		}
 
 		@Test
-		@DisplayName("success: 가격 범위 재설정 - minPrice가 Integer.Max_VALUE인 경우")
+		@DisplayName("success: 가격 범위 재설정 - minPrice = Integer.Max_VALUE인 경우, 가격 범위를 '아이템 최고가 ~ Integer.MAX_VALUE'로 재설정")
 		void getItemListWhenMinPriceIsMaxValue() {
 			// given
-			Pageable pageable = PageRequest.of(1, 10);
+			int page = 0;
+			int size = 10;
+			Pageable pageable = PageRequest.of(page, size);
 			when(itemRepository.findHighestItemPrice()).thenReturn(Optional.of(5000));
 			List<Item> itemList = Collections.singletonList(SharedData.ITEM2);
 			Page<Item> itemPage = new PageImpl<>(itemList, pageable, itemList.size());
@@ -334,26 +342,32 @@ class ItemServiceTest {
 				given(ItemResponseDto.from(any(Item.class))).willReturn(SharedData.ITEM_RESPONSE_DTO);
 
 				// when
-				Page<ItemResponseDto> actualResult = itemService.getItemList(2, 10, Integer.MAX_VALUE, 5000,
+				GetItemListResponseDto actualResult = itemService.getItemList(page, size, Integer.MAX_VALUE, 5000,
 					SharedData.ITEM_NAME2);
 
 				// then
 				verify(itemRepository).findHighestItemPrice();
 				verify(itemRepository).findByPriceWithItemName(pageable, 5000, Integer.MAX_VALUE,
 					SharedData.ITEM_NAME2);
+
+				assertThat(actualResult).isNotNull();
+				assertThat(actualResult.getMaxPrice()).isEqualTo(Integer.MAX_VALUE);
+				assertThat(actualResult.getMinPrice()).isEqualTo(5000);
 			}
 		}
 
 		@Test
-		@DisplayName("success: maxPrice 재설정 - maxPrice가 minPrice보다 작을 경우")
+		@DisplayName("success: maxPrice 재설정 - maxPrice <= minPrice인 경우, 가격 범위를 'minPrice ~ 아이템 최고가'로 재설정")
 		void getItemListWhenMaxPriceLessThanOrEqualToMinPrice() {
 			// given
-			Pageable pageable = PageRequest.of(1, 10);
+			int page = 0;
+			int size = 10;
+			Pageable pageable = PageRequest.of(page, size);
 			when(itemRepository.findHighestItemPrice()).thenReturn(Optional.of(6000));
 			List<Item> itemList = Collections.singletonList(SharedData.ITEM2);
 			Page<Item> itemPage = new PageImpl<>(itemList, pageable, itemList.size());
 
-			when(itemRepository.findByPriceWithItemName(pageable, 1000, 6000, SharedData.ITEM_NAME2)).thenReturn(
+			when(itemRepository.findByPriceWithItemName(pageable, 5000, 6000, SharedData.ITEM_NAME2)).thenReturn(
 				itemPage);
 
 			try (MockedStatic<ItemResponseDto> mockedStatic = mockStatic(ItemResponseDto.class)) {
@@ -361,11 +375,15 @@ class ItemServiceTest {
 
 				// when
 				// maxPrice가 minPrice보다 작음
-				Page<ItemResponseDto> actualResult = itemService.getItemList(2, 10, 5000, 1000, SharedData.ITEM_NAME2);
+				GetItemListResponseDto actualResult = itemService.getItemList(page, size, 5000, 1000, SharedData.ITEM_NAME2);
 
 				// then
 				verify(itemRepository).findHighestItemPrice();
-				verify(itemRepository).findByPriceWithItemName(pageable, 1000, 6000, SharedData.ITEM_NAME2);
+				verify(itemRepository).findByPriceWithItemName(pageable, 5000, 6000, SharedData.ITEM_NAME2);
+
+				assertThat(actualResult).isNotNull();
+				assertThat(actualResult.getMaxPrice()).isEqualTo(6000);
+				assertThat(actualResult.getMinPrice()).isEqualTo(5000);
 			}
 		}
 
@@ -373,28 +391,32 @@ class ItemServiceTest {
 		@DisplayName("success: 아이템이 없을 경우 빈 페이지 반환")
 		void getItemListWhenNoItems() {
 			// given
-			Pageable pageable = PageRequest.of(0, 10);
+			int page = 0;
+			int size = 10;
+			Pageable pageable = PageRequest.of(page, size);
 			when(itemRepository.findHighestItemPrice()).thenReturn(Optional.of(5000));
 			Page<Item> emptyPage = Page.empty();
 			when(itemRepository.findByPriceWithItemName(eq(pageable), anyInt(), anyInt(), anyString())).thenReturn(
 				emptyPage);
 
 			// when
-			Page<ItemResponseDto> actualResult = itemService.getItemList(1, 10, 1000, 5000, SharedData.ITEM_NAME2);
+			GetItemListResponseDto actualResult = itemService.getItemList(page, size, 1000, 5000, SharedData.ITEM_NAME2);
 
 			// then
 			verify(itemRepository).findHighestItemPrice();
 			verify(itemRepository).findByPriceWithItemName(eq(pageable), anyInt(), anyInt(), anyString());
 
 			assertThat(actualResult).isNotNull();
-			assertThat(actualResult.getTotalElements()).isEqualTo(0);
+			assertThat(actualResult.getResponseDtoPage().getTotalElements()).isEqualTo(0);
 		}
 
 		@Test
 		@DisplayName("success: itemName이 null일 때 전체 목록 반환")
 		void getItemListWhenItemNameIsNull() {
 			// given
-			Pageable pageable = PageRequest.of(0, 10);
+			int page = 0;
+			int size = 10;
+			Pageable pageable = PageRequest.of(page, size);
 			when(itemRepository.findHighestItemPrice()).thenReturn(Optional.of(5000));
 			List<Item> itemList = Arrays.asList(SharedData.ITEM1, SharedData.ITEM2);
 			Page<Item> itemPage = new PageImpl<>(itemList, pageable, itemList.size());
@@ -406,13 +428,13 @@ class ItemServiceTest {
 				given(ItemResponseDto.from(any(Item.class))).willReturn(SharedData.ITEM_RESPONSE_DTO);
 
 				// when
-				Page<ItemResponseDto> actualResult = itemService.getItemList(1, 10, 1000, 5000, null);
+				GetItemListResponseDto actualResult = itemService.getItemList(page, size, 1000, 5000, null);
 
 				// then
 				verify(itemRepository).findHighestItemPrice();
 				verify(itemRepository).findByPriceWithItemName(eq(pageable), anyInt(), anyInt(), isNull());
 
-				assertThat(actualResult.getTotalElements()).isEqualTo(itemList.size());
+				assertThat(actualResult.getResponseDtoPage().getTotalElements()).isEqualTo(itemList.size());
 			}
 		}
 	}

--- a/src/test/java/excluz/excluz/domain/store/store/service/StoreServiceTest.java
+++ b/src/test/java/excluz/excluz/domain/store/store/service/StoreServiceTest.java
@@ -38,7 +38,6 @@ import excluz.excluz.domain.store.store.dto.response.StoreDetailResponseDto;
 import excluz.excluz.domain.store.store.dto.response.StoreNameResponseDto;
 import excluz.excluz.domain.store.store.dto.response.StoreResponseDto;
 import excluz.excluz.domain.store.store.repository.StoreRepository;
-import excluz.excluz.domain.streamer.repository.StreamerRepository;
 import excluz.excluz.domain.streamer.service.StreamerService;
 
 @ExtendWith(MockitoExtension.class)
@@ -53,13 +52,9 @@ public class StoreServiceTest {
 	@Mock
 	ItemRepository itemRepository;
 	@Mock
-	StreamerRepository streamerRepository;
-	@Mock
 	StreamerService streamerService;
 	@Mock
 	PasswordEncoder passwordEncoder;
-	@Mock
-	Store mockStore;
 	@Mock
 	Streamer mockStreamer;
 
@@ -182,7 +177,7 @@ public class StoreServiceTest {
 			// given
 			int page = 1;
 			int size = 10;
-			Pageable pageable = PageRequest.of(page-1, size);
+			Pageable pageable = PageRequest.of(page, size);
 			Store store = SharedData.STORE1;
 			List<Store> storeList = Collections.singletonList(store);
 			Page<Store> storePage = new PageImpl<>(storeList, pageable, storeList.size());
@@ -213,7 +208,7 @@ public class StoreServiceTest {
 			// given
 			int page = 1;
 			int size = 10;
-			Pageable pageable = PageRequest.of(page-1, size);
+			Pageable pageable = PageRequest.of(page, size);
 			when(storeRepository.findStreamerWithStore(anyInt())).thenReturn(Optional.of(SharedData.STREAMER1));
 
 			when(storeRepository.findById(SharedData.STORE_ID1)).thenReturn(Optional.of(SharedData.STORE1));
@@ -252,7 +247,7 @@ public class StoreServiceTest {
 			ReflectionTestUtils.setField(SharedData.STORE1, "id", SharedData.STORE_ID1);
 			int page = 1;
 			int size = 10;
-			Pageable pageable = PageRequest.of(page-1, size);
+			Pageable pageable = PageRequest.of(page, size);
 			when(streamerService.findStreamerById(SharedData.STREAMER_ID1)).thenReturn(SharedData.STREAMER1);
 			when(storeRepository.findStoreWithStreamer(SharedData.STREAMER_ID1)).thenReturn(Optional.of(SharedData.STORE1));
 

--- a/src/test/java/excluz/excluz/domain/store/store/service/StoreServiceTest.java
+++ b/src/test/java/excluz/excluz/domain/store/store/service/StoreServiceTest.java
@@ -102,20 +102,19 @@ public class StoreServiceTest {
 
 			when(streamerService.findStreamerById(anyInt())).thenReturn(SharedData.STREAMER1);
 			when(passwordEncoder.matches(anyString(), anyString())).thenReturn(true);
-			when(storeRepository.findById(SharedData.STORE_ID1)).thenReturn(Optional.of(spyStore));
+			when(storeRepository.findStoreWithStreamer(SharedData.STREAMER_ID1)).thenReturn(Optional.of(spyStore));
 
 			// 삭제 상태 변경 전 검증
 			assertThat(spyStore.isDeleted()).isEqualTo(false);
 
 			// when
-			storeService.deleteStore(deleteRequestDto, SharedData.STREAMER_ID1, SharedData.STORE_ID1);
+			storeService.deleteStore(deleteRequestDto, SharedData.STREAMER_ID1);
 
 			// then
 			verify(streamerService).findStreamerById(SharedData.STREAMER_ID1);
 			verify(passwordEncoder).matches(SharedData.STREAMER_PASSWORD1, SharedData.STREAMER_PASSWORD1);
-			verify(storeRepository).findById(SharedData.STORE_ID1);
+			verify(storeRepository).findStoreWithStreamer(SharedData.STREAMER_ID1);
 			verify(spyStore).updateIsDeleted(true);
-
 			// 삭제 상태 변경 후 검증
 			assertThat(spyStore.isDeleted()).isEqualTo(true);
 		}
@@ -129,7 +128,7 @@ public class StoreServiceTest {
 	class UpdateStore {
 
 		@Test
-		@DisplayName("success: 스토어 주인은 스토어 정보 수정 가능")
+		@DisplayName("success: 스토어 주인만 스토어 정보 수정 가능")
 		void updateStore() {
 			// given
 			StoreUpdateRequestDto requestDto = new StoreUpdateRequestDto(SharedData.ADDRESS2, SharedData.STORE_NAME2, SharedData.REGISTRATION_NUMBER2);

--- a/src/test/java/excluz/excluz/domain/streamer/service/StreamerServiceTest.java
+++ b/src/test/java/excluz/excluz/domain/streamer/service/StreamerServiceTest.java
@@ -64,23 +64,30 @@ class StreamerServiceTest {
 		void streamerSignup() {
 			// given
 			StreamerSignupRequestDto signupRequestDto = SharedData.STREAMER_SIGNUP_REQUEST_DTO;
+			StreamerResponseDto responseDto = new StreamerResponseDto(SharedData.STREAMER_ID1, SharedData.STREAMER_NAME1, SharedData.STREAMER_NICKNAME1, SharedData.STREAMER_PHONE_NUMBER1, SharedData.STREAMER_EMAIL1);
 			when(passwordEncoder.encode(signupRequestDto.getPassword())).thenReturn("encodedPassword");
+			when(streamerRepository.save(any(Streamer.class))).thenReturn(SharedData.STREAMER1);
 
-			// when
-			streamerService.streamerSignup(signupRequestDto);
+			try (MockedStatic<StreamerResponseDto> mockedStatic = mockStatic(StreamerResponseDto.class)) {
+				mockedStatic.when(()->StreamerResponseDto.from(any(Streamer.class))).thenReturn(responseDto);
 
-			// then
-			verify(passwordEncoder).encode(signupRequestDto.getPassword());
-			// save() 인자 캡쳐
-			ArgumentCaptor<Streamer> streamerCaptor = ArgumentCaptor.forClass(Streamer.class);
-			verify(streamerRepository).save(streamerCaptor.capture());
-			Streamer streamer = streamerCaptor.getValue();
-			// save() 인자 검증
-			assertThat(streamer.getEmail()).isEqualTo(signupRequestDto.getEmail());
-			assertThat(streamer.getName()).isEqualTo(signupRequestDto.getName());
-			assertThat(streamer.getNickName()).isEqualTo(signupRequestDto.getNickName());
-			assertThat(streamer.getPhoneNumber()).isEqualTo(signupRequestDto.getPhoneNumber());
-			assertThat(streamer.getPassword()).isEqualTo("encodedPassword");
+				// when
+				StreamerResponseDto actualResult = streamerService.streamerSignup(signupRequestDto);
+
+				// then
+				verify(passwordEncoder).encode(signupRequestDto.getPassword());
+
+				assertThat(actualResult.getEmail()).isEqualTo(signupRequestDto.getEmail());
+				assertThat(actualResult.getName()).isEqualTo(signupRequestDto.getName());
+				assertThat(actualResult.getNickName()).isEqualTo(signupRequestDto.getNickName());
+				assertThat(actualResult.getPhoneNumber()).isEqualTo(signupRequestDto.getPhoneNumber());
+				// save() 인자 캡쳐
+				ArgumentCaptor<Streamer> streamerCaptor = ArgumentCaptor.forClass(Streamer.class);
+				verify(streamerRepository).save(streamerCaptor.capture());
+				Streamer streamer = streamerCaptor.getValue();
+				// save() 인자 중 password 검증
+				assertThat(streamer.getPassword()).isEqualTo("encodedPassword");
+			}
 		}
 
 		@Test
@@ -124,7 +131,7 @@ class StreamerServiceTest {
 			when(jwtUtil.createToken(SharedData.STREAMER1.getEmail(), SharedData.STREAMER1.getId(),	SharedData.STREAMER1.getUserRole())).thenReturn(token);
 
 			try (MockedStatic<StreamerLoginResponseDto> mockedStatic = mockStatic(StreamerLoginResponseDto.class)) {
-				given(StreamerLoginResponseDto.from(anyString())).willReturn(loginResponseDto);
+				mockedStatic.when(()->StreamerLoginResponseDto.from(anyString())).thenReturn(loginResponseDto);
 
 				// when
 				StreamerLoginResponseDto actualResult = streamerService.streamerLogin(loginRequestDto);
@@ -249,6 +256,7 @@ class StreamerServiceTest {
 				SharedData.STREAMER_EMAIL2,
 				SharedData.STREAMER_PASSWORD1);
 			StreamerResponseDto responseDto = new StreamerResponseDto(
+				SharedData.STREAMER_ID1,
 				SharedData.STREAMER_NAME2,
 				SharedData.STREAMER_NICKNAME2,
 				SharedData.STREAMER_PHONE_NUMBER2,
@@ -270,6 +278,7 @@ class StreamerServiceTest {
 				// Dto 검증
 				assertNotNull(actualResult);
 				// 수정 된 값 검증
+				assertThat(actualResult.getStreamerId()).isEqualTo(SharedData.STREAMER_ID1);
 				assertThat(actualResult.getEmail()).isEqualTo(requestDto.getEmail());
 				assertThat(actualResult.getName()).isEqualTo(requestDto.getName());
 				assertThat(actualResult.getNickName()).isEqualTo(requestDto.getNickName());
@@ -327,6 +336,7 @@ class StreamerServiceTest {
 		void getPersonalInfo() {
 			// given
 			StreamerResponseDto responseDto = new StreamerResponseDto(
+				SharedData.STREAMER_ID1,
 				SharedData.STREAMER_NAME1,
 				SharedData.STREAMER_NICKNAME1,
 				SharedData.STREAMER_PHONE_NUMBER1,
@@ -347,6 +357,7 @@ class StreamerServiceTest {
 				// Dto 검증
 				assertNotNull(actualResult);
 				// 조회 된 값 검증
+				assertThat(actualResult.getStreamerId()).isEqualTo(SharedData.STREAMER_ID1);
 				assertThat(actualResult.getEmail()).isEqualTo(spyStreamer.getEmail());
 				assertThat(actualResult.getName()).isEqualTo(spyStreamer.getName());
 				assertThat(actualResult.getNickName()).isEqualTo(spyStreamer.getNickName());
@@ -393,7 +404,7 @@ class StreamerServiceTest {
 			// given
 			int page = 1;
 			int size = 10;
-			Pageable pageable = PageRequest.of(page - 1, size);
+			Pageable pageable = PageRequest.of(page, size);
 			StreamerSummaryResponseDto responseDto = new StreamerSummaryResponseDto(SharedData.STREAMER_NICKNAME1, SharedData.STREAMER_ID1);
 
 			List<Streamer> streamerList = Collections.singletonList(SharedData.STREAMER1);


### PR DESCRIPTION
## 목적
수정 요청 사항을 모두 반영했습니다.

## 변경점
### 스토어 등록
- 삭제 되지 않은 스토어 중, 중복되는 사업자 번호를 가진 스토어 등록시 409 Confilt 예외를 반환합니다. 
- 스토어 등록 시점에 운영중인 스토어가 있을경우 등록을 제한 합니다.

### 스토어 삭제
- URL을 `/api/v1/stores/my-store/soft`로 변경했습니다.
- JWT 토큰을 활용해 본인의 가게에만 접근하도록 하여, 비밀번호만 알면 주인이 아닌 스토어를 삭제할 수 있는 상황을 방지했습니다. (보안 강화)

### 아이템 조건 검색
- 아이템 검색 시, 설정된 minPrice ~ maxPrice 범위를 함께 반환하도록 했습니다.
- minPrice ~ maxPrice 재설정 로직을 개선했습니다.

### 페이지 네이션
- Page의 기본값을 0으로 수정했습니다. (관련 서비스 로직도 수정함)

## To 리뷰어
- 수정된 로직이 정상적으로 동작하는지 포스트맨을 통해 확인했습니다.
- 관련 테스트 코드역시 수정 완료했습니다. (테스트 통과여부 확인 완료)