### PR TITLE
:recycle:refactor:Get event by Pagination

### DIFF
--- a/src/main/java/excluz/excluz/domain/event/event/controller/EventController.java
+++ b/src/main/java/excluz/excluz/domain/event/event/controller/EventController.java
@@ -10,6 +10,7 @@ import excluz.excluz.domain.event.event.service.EventService;
 import excluz.excluz.domain.user.enums.UserRole;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -55,9 +56,10 @@ public class EventController {
 
     @GetMapping()
     @PreAuthorize("hasRole('STREAMER')")
-    public ResponseEntity<List<EventResponseDto>> getAllEvents() {
+    public ResponseEntity<Page<EventResponseDto>> getAllEvents(@RequestParam(defaultValue = "0") int page,
+                                                               @RequestParam(defaultValue = "10") int size) {
         Integer streamerId = SecurityContextUtil.getUserOrStreamerId();
-        List<EventResponseDto> eventResponseDtoList = eventService.getAllEvents(streamerId);
+        Page<EventResponseDto> eventResponseDtoList = eventService.getEventList(streamerId, page, size);
         return ResponseEntity.ok(eventResponseDtoList);
     }
 

--- a/src/main/java/excluz/excluz/domain/event/event/dto/EventResponseDto.java
+++ b/src/main/java/excluz/excluz/domain/event/event/dto/EventResponseDto.java
@@ -2,6 +2,8 @@ package excluz.excluz.domain.event.event.dto;
 
 import excluz.excluz.common.entity.Event;
 import excluz.excluz.common.entity.EventItem;
+import excluz.excluz.domain.event.event.enums.ParticipantCondition;
+import excluz.excluz.domain.event.event.enums.SelectionMethod;
 import excluz.excluz.domain.event.eventItem.dto.EventItemDto;
 import lombok.Builder;
 import lombok.Getter;
@@ -17,8 +19,8 @@ public class EventResponseDto {
     private Integer id;
     private Integer streamerStoreId;
     private Integer numberOfWinners;
-    private String participantCondition;
-    private String selectionMethod;
+    private ParticipantCondition participantCondition;
+    private SelectionMethod selectionMethod;
     private LocalDateTime startDatetime;
     private LocalDateTime endDatetime;
     private Boolean isCompleted;
@@ -31,8 +33,8 @@ public class EventResponseDto {
     public EventResponseDto(Integer id,
                             Integer streamerStoreId,
                             Integer numberOfWinners,
-                            String participantCondition,
-                            String selectionMethod,
+                            ParticipantCondition participantCondition,
+                            SelectionMethod selectionMethod,
                             LocalDateTime startDatetime,
                             LocalDateTime endDatetime,
                             Boolean isCompleted,
@@ -72,8 +74,8 @@ public class EventResponseDto {
                 .id(event.getId())
                 .streamerStoreId(event.getStore().getId())
                 .numberOfWinners(event.getNumberOfWinners())
-                .participantCondition(event.getParticipantCondition().name())
-                .selectionMethod(event.getSelectionMethod().name())
+                .participantCondition(event.getParticipantCondition())
+                .selectionMethod(event.getSelectionMethod())
                 .startDatetime(event.getStartDatetime())
                 .endDatetime(event.getEndDatetime())
                 .isCompleted(event.getIsCompleted())
@@ -90,8 +92,8 @@ public class EventResponseDto {
                 .id(event.getId())
                 .streamerStoreId(event.getStore().getId())
                 .numberOfWinners(event.getNumberOfWinners())
-                .participantCondition(event.getParticipantCondition().name())
-                .selectionMethod(event.getSelectionMethod().name())
+                .participantCondition(event.getParticipantCondition())
+                .selectionMethod(event.getSelectionMethod())
                 .startDatetime(event.getStartDatetime())
                 .endDatetime(event.getEndDatetime())
                 .isCompleted(event.getIsCompleted())

--- a/src/main/java/excluz/excluz/domain/event/event/repository/EventRepository.java
+++ b/src/main/java/excluz/excluz/domain/event/event/repository/EventRepository.java
@@ -1,6 +1,10 @@
 package excluz.excluz.domain.event.event.repository;
 
+import excluz.excluz.common.entity.Store;
+import excluz.excluz.domain.event.event.dto.EventResponseDto;
 import jakarta.persistence.LockModeType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import excluz.excluz.common.entity.Event;
 import org.springframework.data.jpa.repository.Lock;
@@ -11,10 +15,17 @@ import java.util.Optional;
 
 public interface EventRepository extends JpaRepository<Event, Integer> {
 
-//    todo: 낙관적/비관적 락 테스트
+
+    @Query("SELECT new excluz.excluz.domain.event.event.dto.EventResponseDto(" +
+            "e.id, e.store.id, e.numberOfWinners, e.participantCondition, e.selectionMethod, e.startDatetime, e.endDatetime, e.isCompleted, " +
+            "e.createdAt, e.updatedAt, e.generatedCode, null) " +
+            "FROM Event e " +
+            "JOIN e.store s " +
+            "JOIN s.streamer st " +
+            "WHERE st.id = :streamerId")
+    Page<EventResponseDto> findByStreamerId(@Param("streamerId") Integer streamerId, Pageable pageable);
+
     @Lock(LockModeType.PESSIMISTIC_WRITE)
-//    @Lock(LockModeType.PESSIMISTIC_READ)
-//    @Lock(LockModeType.OPTIMISTIC)
     @Query("SELECT e FROM Event e WHERE e.generatedCode = :code")
     Optional<Event> findByGeneratedCode(@Param("code") String generatedCode);
 }

--- a/src/main/java/excluz/excluz/domain/event/event/service/EventService.java
+++ b/src/main/java/excluz/excluz/domain/event/event/service/EventService.java
@@ -22,6 +22,9 @@ import excluz.excluz.domain.event.event.dto.EventResponseDto;
 import excluz.excluz.domain.streamer.repository.StreamerRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -95,18 +98,15 @@ public class EventService {
 
     // 이벤트 전체 조회 서비스 로직
     @Transactional(readOnly = true)
-    public List<EventResponseDto> getAllEvents(Integer streamerId) {
+    public Page<EventResponseDto> getEventList(Integer streamerId, int page, int size) {
+        // 스트리머 존재 여부 확인 (없으면 예외)
         Streamer streamer = streamerRepository.findById(streamerId)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND));
 
-        List<Event> events = eventRepository.findAll().stream()
-                .filter(event -> event.getStore().getStreamer().getId().equals(streamer.getId()))
-                .toList();
+        Pageable pageable = PageRequest.of(Math.max(0, page), size);
 
-        // EventResponseDto로 변환하여 반환
-        return events.stream()
-                .map(EventResponseDto::fromWithoutItems)
-                .collect(Collectors.toList());
+        // 스트리머에 해당하는 이벤트를 직접 조회 (페이지 적용)
+        return eventRepository.findByStreamerId(streamer.getId(), pageable);
     }
 
 

--- a/src/test/java/excluz/excluz/domain/event/service/EventServiceTest.java
+++ b/src/test/java/excluz/excluz/domain/event/service/EventServiceTest.java
@@ -35,6 +35,10 @@ import org.mockito.MockitoAnnotations;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDateTime;
@@ -365,17 +369,26 @@ public class EventServiceTest {
         Event event2 = createTestEvent();
         ReflectionTestUtils.setField(event2, "id", 2);
         List<Event> events = Arrays.asList(event1, event2);
-        when(eventRepository.findAll()).thenReturn(events);
+        // EventResponseDto로 변환하여 리스트 준비
+        List<EventResponseDto> dtoList = new ArrayList<>();
+        for (Event event : events) {
+            dtoList.add(EventResponseDto.fromWithoutItems(event));
+        }
 
-        List<Event> eventResponseList = Arrays.asList(event1, event2);
-        when(eventRepository.findAll()).thenReturn(eventResponseList);
+// 페이징 객체 준비 (예: page=0, size=10)
+        Pageable pageable = PageRequest.of(0, 10);
+        Page<EventResponseDto> page = new PageImpl<>(dtoList, pageable, dtoList.size());
 
-        // when
-        List<EventResponseDto> eventList = eventService.getAllEvents(testStreamer.getId());
+// 변경된 Repository 메서드( findByStreamerId )를 stub 처리합니다.
+        when(eventRepository.findByStreamerId(eq(testStreamer.getId()), any(Pageable.class)))
+                .thenReturn(page);
 
-        // then
-        Assertions.assertThat(eventList).isNotNull();
-        Assertions.assertThat(eventList.size()).isGreaterThanOrEqualTo(2);
+// when
+        Page<EventResponseDto> eventListPage = eventService.getEventList(testStreamer.getId(), 0, 10);
+
+// then
+        Assertions.assertThat(eventListPage).isNotNull();
+        Assertions.assertThat(eventListPage.getContent().size()).isGreaterThanOrEqualTo(2);
     }
 
     @Test


### PR DESCRIPTION
## 목적 🎯 
Event의 View에서 오류를 줄이기 위해 페이지네이션 추가

## 변경점 ✔️ 
전체 조회를 JPQL기반 페이지네이션 조회(EventController, EventService, EventRepository)
→ (사이드 이펙트) EventResponseDto에서 Enum을 직접 참조하도록 함

## 리뷰어에게 🙇 
기존의 테스트 postman은 동일하게 작동함을 확인했습니다. JPQL코드에 논리적 맹점 같은 걸 한 번씩 검토 부탁드려요