### PR TITLE
🚑 fix: findByStreamerId duplicate problem in orderRepository

### DIFF
--- a/src/main/java/excluz/excluz/domain/order/order/repository/OrderRepository.java
+++ b/src/main/java/excluz/excluz/domain/order/order/repository/OrderRepository.java
@@ -17,7 +17,7 @@ public interface OrderRepository extends JpaRepository<Order, Integer> {
             "WHERE o.user.id = :userId")
     Page<OrderResponseDto> findByUserId(@Param("userId") Integer userId, Pageable pageable);
 
-    @Query("SELECT new excluz.excluz.domain.order.order.dto.response.OrderResponseDto(" +
+    @Query("SELECT DISTINCT new excluz.excluz.domain.order.order.dto.response.OrderResponseDto(" +
             "o.id, o.orderStatus, o.address, o.updatedAt) " +
             "FROM Order o " +
             "LEFT JOIN OrderItem oi ON oi.order = o " +

--- a/src/main/java/excluz/excluz/domain/order/orderItem/repository/OrderItemRepository.java
+++ b/src/main/java/excluz/excluz/domain/order/orderItem/repository/OrderItemRepository.java
@@ -24,7 +24,7 @@ public interface OrderItemRepository extends JpaRepository<OrderItem, Integer> {
     Page<OrderItemResponseDto> findByUserId(@Param("userId") Integer userId, Pageable pageable);
 
     @Query("SELECT new excluz.excluz.domain.order.orderItem.dto.response.OrderItemResponseDto(" +
-            "oi.id, o.id, u.nickName, i.id, i.itemName, i.price, oi.item_quantity, o.createdAt) " +
+            "o.id, oi.id, u.nickName, i.id, i.itemName, i.price, oi.item_quantity, o.createdAt) " +
             "FROM OrderItem oi " +
             "JOIN oi.order o " +
             "JOIN o.user u " +


### PR DESCRIPTION
## 목적
- orderId가 유일하나 중복으로 2개가 조회되는 문제 해결

## 변경점
- OrderRepository에 "DISTINCT" 추가