### PR TITLE
♻️ refactor: Optimize CartItem bulk retrieval logic for performance

### DIFF
--- a/src/main/java/excluz/excluz/domain/cartItem/controller/CartItemV2Controller.java
+++ b/src/main/java/excluz/excluz/domain/cartItem/controller/CartItemV2Controller.java
@@ -12,21 +12,35 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/v2/cart-items")
+@RequestMapping("/api")
 @RequiredArgsConstructor
 public class CartItemV2Controller {
 
     private final CartItemV2Service cartItemV2Service;
 
-    @GetMapping
-    public ResponseEntity<CartItemListResponseDto> getCartItemList(
-            @RequestParam(defaultValue = "0") int page,     // 기본값 0 (첫 페이지)
-            @RequestParam(defaultValue = "10") int size     // 기본값 10 (한 페이지당 10개)
+    // v2-1 : fetchJoin() 제외 QueryDSL 방식
+    @GetMapping("/v2-1/cart-items")
+    public ResponseEntity<CartItemListResponseDto> getCartItemListV1(
+        @RequestParam(defaultValue = "0") int page,     // 기본값 0 (첫 페이지)
+        @RequestParam(defaultValue = "10") int size     // 기본값 10 (한 페이지당 10개)
     ) {
         Integer userId = SecurityContextUtil.getUserOrStreamerId();
         UserRole userRole = SecurityContextUtil.getUserRole();
 
-        CartItemListResponseDto response = cartItemV2Service.getCartItemList(userId, userRole, page, size);
+        CartItemListResponseDto response = cartItemV2Service.getCartItemListV1(userId, userRole, page, size);
+        return ResponseEntity.ok(response);
+    }
+
+    // v2-2 : fetchJoin() 포함 QueryDSL 방식
+    @GetMapping("/v2-2/cart-items")
+    public ResponseEntity<CartItemListResponseDto> getCartItemListV2(
+        @RequestParam(defaultValue = "0") int page,     // 기본값 0 (첫 페이지)
+        @RequestParam(defaultValue = "10") int size     // 기본값 10 (한 페이지당 10개)
+    ) {
+        Integer userId = SecurityContextUtil.getUserOrStreamerId();
+        UserRole userRole = SecurityContextUtil.getUserRole();
+
+        CartItemListResponseDto response = cartItemV2Service.getCartItemListV2(userId, userRole, page, size);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/excluz/excluz/domain/cartItem/repository/CartItemRepository.java
+++ b/src/main/java/excluz/excluz/domain/cartItem/repository/CartItemRepository.java
@@ -13,13 +13,6 @@ import org.springframework.data.repository.query.Param;
 
 public interface CartItemRepository extends JpaRepository<CartItem, Integer> {
 	// 특정 유저의 모든 장바구니 아이템 조회(다건 조회)
-	@Query("SELECT ci FROM CartItem ci " +
-			"LEFT JOIN FETCH ci.item " +
-			"LEFT JOIN FETCH ci.item.store " +
-			"LEFT JOIN FETCH ci.user " +  // N+1 문제 방지
-			"WHERE ci.user.id = :userId")
-	List<CartItem> findByUserId(@Param("userId") Integer userId);
-
 	@Query(
 		value = "SELECT ci FROM CartItem ci " +
 			"LEFT JOIN FETCH ci.item " +

--- a/src/main/java/excluz/excluz/domain/cartItem/repository/CartItemV2Repository.java
+++ b/src/main/java/excluz/excluz/domain/cartItem/repository/CartItemV2Repository.java
@@ -1,8 +1,10 @@
 package excluz.excluz.domain.cartItem.repository;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
+
 import excluz.excluz.common.entity.CartItem;
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -21,28 +23,53 @@ import static excluz.excluz.common.entity.QUser.user;
 public class CartItemV2Repository {
     private final JPAQueryFactory queryFactory;
 
-    public Page<CartItem> findByUserId(Integer userId, Pageable pageable) {
+    // v2-1 : fetchJoin() 제외 QueryDSL 방식
+    public Page<CartItem> findByUserIdV1(Integer userId, Pageable pageable) {
         // 메인 쿼리 (데이터 조회)
         List<CartItem> cartItems = queryFactory
-                .selectFrom(cartItem)
-                .leftJoin(cartItem.item, item).fetchJoin()
-                .leftJoin(item.store, store).fetchJoin()
-                .leftJoin(cartItem.user, user).fetchJoin()
-                .where(cartItem.user.id.eq(userId))
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
-                .fetch();
+            .selectFrom(cartItem)
+            .leftJoin(cartItem.item, item)
+            .leftJoin(item.store, store)
+            .leftJoin(cartItem.user, user)
+            .where(cartItem.user.id.eq(userId))
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch();
 
         // 전체 개수 조회 (페이징을 위해 필요)
         Long totalCount = Optional.ofNullable(
-                queryFactory
-                        .select(cartItem.count())
-                        .from(cartItem)
-                        .where(cartItem.user.id.eq(userId))
-                        .fetchOne()
+            queryFactory
+                .select(cartItem.count())
+                .from(cartItem)
+                .where(cartItem.user.id.eq(userId))
+                .fetchOne()
         ).orElse(0L);
 
         return new PageImpl<>(cartItems, pageable, totalCount);
     }
 
+    // v2-2 : fetchJoin() 포함 QueryDSL 방식
+    public Page<CartItem> findByUserIdV2(Integer userId, Pageable pageable) {
+        // 메인 쿼리 (데이터 조회)
+        List<CartItem> cartItems = queryFactory
+            .selectFrom(cartItem)
+            .leftJoin(cartItem.item, item).fetchJoin()
+            .leftJoin(item.store, store).fetchJoin()
+            .leftJoin(cartItem.user, user).fetchJoin()
+            .where(cartItem.user.id.eq(userId))
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch();
+
+        // 전체 개수 조회 (페이징을 위해 필요)
+        Long totalCount = Optional.ofNullable(
+            queryFactory
+                .select(cartItem.count())
+                .from(cartItem)
+                .where(cartItem.user.id.eq(userId))
+                .fetchOne()
+        ).orElse(0L);
+
+        return new PageImpl<>(cartItems, pageable, totalCount);
+    }
 }

--- a/src/main/java/excluz/excluz/domain/cartItem/service/CartItemV2Service.java
+++ b/src/main/java/excluz/excluz/domain/cartItem/service/CartItemV2Service.java
@@ -20,8 +20,9 @@ public class CartItemV2Service {
 
     private final CartItemV2Repository cartItemV2Repository;
 
+    // v2-1 : fetchJoin() 제외 QueryDSL 방식
     @Transactional(readOnly = true)
-    public CartItemListResponseDto getCartItemList(Integer userId, UserRole userRole, int page, int size) {
+    public CartItemListResponseDto getCartItemListV1(Integer userId, UserRole userRole, int page, int size) {
 
         Pageable pageable = PageRequest.of(Math.max(page - 1, 0), size);
         // 장바구니 이용은 CUSTOMER만 가능
@@ -29,15 +30,38 @@ public class CartItemV2Service {
             throw new ForbiddenException(ErrorCode.FORBIDDEN_USER_ACCESS);
         }
 
-        Page<CartItem> cartItems = cartItemV2Repository.findByUserId(userId, pageable);
+        Page<CartItem> cartItems = cartItemV2Repository.findByUserIdV1(userId, pageable);
 
         Page<GetCartItemResponseDto> cartItemList = cartItems.map(item -> GetCartItemResponseDto.builder()
-                .cartItemId(item.getId())                  // 장바구니 아이템의 ID
-                .itemId(item.getItem().getId())              // 연결된 상품의 ID
-                .storeId(item.getItem().getStore().getId())    // 해당 상품이 속한 상점의 ID
-                .quantity(item.getQuantity())                // 주문 수량
-                .itemPrice(item.getItem().getPrice())          // 상품 가격
-                .build());
+            .cartItemId(item.getId())                  // 장바구니 아이템의 ID
+            .itemId(item.getItem().getId())              // 연결된 상품의 ID
+            .storeId(item.getItem().getStore().getId())    // 해당 상품이 속한 상점의 ID
+            .quantity(item.getQuantity())                // 주문 수량
+            .itemPrice(item.getItem().getPrice())          // 상품 가격
+            .build());
+
+        return new CartItemListResponseDto(cartItemList);
+    }
+
+    // v2-2 : fetchJoin() 포함 QueryDSL 방식
+    @Transactional(readOnly = true)
+    public CartItemListResponseDto getCartItemListV2(Integer userId, UserRole userRole, int page, int size) {
+
+        Pageable pageable = PageRequest.of(Math.max(page - 1, 0), size);
+        // 장바구니 이용은 CUSTOMER만 가능
+        if (userRole != UserRole.CUSTOMER) {
+            throw new ForbiddenException(ErrorCode.FORBIDDEN_USER_ACCESS);
+        }
+
+        Page<CartItem> cartItems = cartItemV2Repository.findByUserIdV2(userId, pageable);
+
+        Page<GetCartItemResponseDto> cartItemList = cartItems.map(item -> GetCartItemResponseDto.builder()
+            .cartItemId(item.getId())                  // 장바구니 아이템의 ID
+            .itemId(item.getItem().getId())              // 연결된 상품의 ID
+            .storeId(item.getItem().getStore().getId())    // 해당 상품이 속한 상점의 ID
+            .quantity(item.getQuantity())                // 주문 수량
+            .itemPrice(item.getItem().getPrice())          // 상품 가격
+            .build());
 
         return new CartItemListResponseDto(cartItemList);
     }

--- a/src/test/java/excluz/excluz/domain/cartItem/service/CartItemServiceTest.java
+++ b/src/test/java/excluz/excluz/domain/cartItem/service/CartItemServiceTest.java
@@ -2,7 +2,6 @@ package excluz.excluz.domain.cartItem.service;
 
 import static org.mockito.Mockito.*;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -13,6 +12,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import excluz.excluz.common.entity.CartItem;
@@ -57,9 +60,10 @@ class CartItemServiceTest {
 	@DisplayName("success: 장바구니 아이템 추가")
 	void addItemToCart() {
 		// given
+		Store store = new Store();
 		User user = mock(User.class);
 		Item item = new Item(
-			null,         // store: null (스토어 정보 없음)
+			store,         // store: 위에서 만든 store
 			"itemName",   // itemName: "itemName" (상품명)
 			"test",       // explanation: "test" (설명)
 			100,          // price: 100 (상품 가격)
@@ -105,9 +109,10 @@ class CartItemServiceTest {
 	@DisplayName("success: 요청 수량 = 재고")
 	void addItemToCartMatchingStockQuantityCase1() {
 		// given
+		Store store = new Store();
 		User user = mock(User.class);
 		Item item = new Item(
-			null,         // store: null (스토어 정보 없음)
+			store,         // store: 위에서 만든 store
 			"itemName",   // itemName: "itemName" (상품명)
 			"test",       // explanation: "test" (설명)
 			100,          // price: 100 (상품 가격)
@@ -147,9 +152,10 @@ class CartItemServiceTest {
 	@DisplayName("success: 장바구니에 있는 수량 + 추가 요청 수량 = 재고")
 	void addItemToCartMatchingStockQuantityCase2() {
 		// given
+		Store store = new Store();
 		User user = mock(User.class);
 		Item item = new Item(
-			null,         // store: null (스토어 정보 없음)
+			store,         // store: 위에서 만든 store
 			"itemName",   // itemName: "itemName" (상품명)
 			"test",       // explanation: "test" (설명)
 			100,          // price: 100 (상품 가격)
@@ -487,26 +493,32 @@ class CartItemServiceTest {
 			3      // quantity: 3 (현재 장바구니에 담긴 수량)
 		);
 
+		int page = 0; // 페이지 번호
+		int size = 10; // 페이지당 아이템 개수
+		Pageable pageable = PageRequest.of(page, size);
+
+		Page<CartItem> cartItemPage = new PageImpl<>(List.of(cartItem1, cartItem2), pageable, 2);
+
 		ReflectionTestUtils.setField(user, "id", 1);
 		ReflectionTestUtils.setField(cartItem1, "id", 1);
 		ReflectionTestUtils.setField(cartItem2, "id", 2);
 
 		UserRole userRole = UserRole.CUSTOMER;
 
-		when(cartItemRepository.findByUserId(user.getId()))
-			.thenReturn(List.of(cartItem1, cartItem2));
+		when(cartItemRepository.findByUserId(eq(user.getId()), any(Pageable.class)))
+			.thenReturn(cartItemPage);
 
 		// when
-		CartItemListResponseDto result = cartItemService.getCartItemList(user.getId(), userRole);
+		CartItemListResponseDto result = cartItemService.getCartItemList(user.getId(), userRole, page, size);
 
 		// then
-		verify(cartItemRepository, times(1)).findByUserId(user.getId()); // findByUserId()가 1번 호출되었는지 확인
+		verify(cartItemRepository, times(1)).findByUserId(eq(user.getId()), any(Pageable.class)); // findByUserIdV1()가 1번 호출되었는지 확인
 
 		Assertions.assertThat(result).isNotNull(); // 결과가 null이 아닌지 확인
 		Assertions.assertThat(result.getCartItemList()).hasSize(2); // 장바구니에 2개 아이템 있는지 확인
 		Assertions.assertThat(result.getTotalPrice()).isEqualTo(800); // (100*2 + 200*3) = 800 확인
-		Assertions.assertThat(result.getCartItemList().get(0).getQuantity()).isEqualTo(2); // 첫 번째 아이템 개수 확인
-		Assertions.assertThat(result.getCartItemList().get(1).getQuantity()).isEqualTo(3); // 두 번째 아이템 개수 확인
+		Assertions.assertThat(result.getCartItemList().getContent().get(0).getQuantity()).isEqualTo(2); // 첫 번째 아이템 개수 확인
+		Assertions.assertThat(result.getCartItemList().getContent().get(1).getQuantity()).isEqualTo(3); // 두 번째 아이템 개수 확인
 	}
 
 	@Test
@@ -516,18 +528,23 @@ class CartItemServiceTest {
 		Integer userId = 1;
 		UserRole userRole = UserRole.CUSTOMER;
 
-		when(cartItemRepository.findByUserId(userId))
-			.thenReturn(Collections.emptyList()); // 빈 리스트 반환
+		int page = 0; // 페이지 번호
+		int size = 10; // 페이지당 아이템 개수
+
+		Page<CartItem> emptyPage = Page.empty();
+
+		when(cartItemRepository.findByUserId(eq(userId), any(Pageable.class)))
+			.thenReturn(emptyPage); // 빈 페이지 반환
 
 		// when
-		CartItemListResponseDto result = cartItemService.getCartItemList(userId, userRole);
+		CartItemListResponseDto result = cartItemService.getCartItemList(userId, userRole, page, size);
 
 		// then
 		Assertions.assertThat(result).isNotNull();
 		Assertions.assertThat(result.getCartItemList()).isEmpty(); // 빈 리스트인지 확인
 		Assertions.assertThat(result.getTotalPrice()).isEqualTo(0); // 총 가격이 0인지 확인
 
-		verify(cartItemRepository, times(1)).findByUserId(userId); // findByUserId()가 1번 호출되었는지 확인
+		verify(cartItemRepository, times(1)).findByUserId(eq(userId), any(Pageable.class)); // findByUserIdV1()가 1번 호출되었는지 확인
 	}
 
 	@Test
@@ -537,8 +554,11 @@ class CartItemServiceTest {
 		Integer userId = 1;
 		UserRole userRole = UserRole.STREAMER; // CUSTOMER가 아닌 경우
 
+		int page = 0; // 페이지 번호
+		int size = 10; // 페이지당 아이템 개수
+
 		// when, then
-		Assertions.assertThatThrownBy(() -> cartItemService.getCartItemList(userId, userRole))
+		Assertions.assertThatThrownBy(() -> cartItemService.getCartItemList(userId, userRole, page, size))
 			.isInstanceOf(ForbiddenException.class); // ForbiddenException 예외 발생
 	}
 
@@ -552,8 +572,9 @@ class CartItemServiceTest {
 	void updateCartItemQuantity() {
 		// given
 		User user = mock(User.class);
+		Store store = new Store();
 		Item item = new Item(
-			null,         // store: null (스토어 정보 없음)
+			store,         // store: 위에서 만든 store
 			"itemName",   // itemName: "itemName" (상품명)
 			"test",       // explanation: "test" (설명)
 			100,          // price: 100 (상품 가격)


### PR DESCRIPTION
## 목적
CartItem 관련 기능의 성능을 최적화하고, 테스트 코드에서 발생한 NullPointerException을 해결

## 변경점
- CartItemServiceTest 수정
   - Item 객체의 Store 필드가 null인 문제 해결
   - Store 객체를 명시적으로 포함하여 Item을 생성하도록 변경
   - 기존 테스트 코드에서 Item을 조회할 때 store 정보를 포함하도록 수정
   - 관련된 단위 테스트를 실행하여 정상 동작 확인

- CartItem 조회 로직 리팩토링
   - 기존 JPQL 방식(V1) → QueryDSL 기반(V2)로 개선
   - fetchJoin()을 활용한 최적화된 조회 방식 추가(V2-2)
   - v1(JPQL): 기존 다건 조회 방식 유지
   - v2-1(QueryDSL, fetchJoin 미포함): QueryDSL 도입, 다건 조회 개선
   - v2-2(QueryDSL, fetchJoin 포함): 성능 최적화를 위한 fetchJoin 활용
