### PR TITLE
:sparkles: feat: add verify email service

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,10 @@ dependencies {
     // Bcrypt
     implementation 'at.favre.lib:bcrypt:0.10.2'
 
+    // 이메일 발송 의존성
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
+    implementation 'ognl:ognl:3.2.21'
+
     // JJWT(Java Json Web Token) 최신버전.
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'

--- a/src/main/java/excluz/excluz/auth/config/EmailConfig.java
+++ b/src/main/java/excluz/excluz/auth/config/EmailConfig.java
@@ -1,0 +1,68 @@
+package excluz.excluz.auth.config;
+
+import java.util.Properties;
+
+import org.springframework.beans.factory.annotation.Value; // Lombok의 Value와 다름.
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+@Configuration
+public class EmailConfig {
+
+	@Value("${spring.mail.host}")
+	private String host;
+
+	@Value("${spring.mail.port}")
+	private int port;
+
+	@Value("${spring.mail.username}")
+	private String username;
+
+	@Value("${spring.mail.password}")
+	private String password;
+
+	@Value("${spring.mail.properties.mail.smtp.auth}")
+	private boolean auth;
+
+	@Value("${spring.mail.properties.mail.smtp.starttls.enable}")
+	private boolean starttlsEnable;
+
+	@Value("${spring.mail.properties.mail.smtp.starttls.required}")
+	private boolean starttlsRequired;
+
+	@Value("${spring.mail.properties.mail.smtp.connectiontimeout}")
+	private int connectionTimeout;
+
+	@Value("${spring.mail.properties.mail.smtp.timeout}")
+	private int timeout;
+
+	@Value("${spring.mail.properties.mail.smtp.writetimeout}")
+	private int writeTimeout;
+
+	@Bean
+	public JavaMailSender javaMailSender() {
+		JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+		mailSender.setHost(host);
+		mailSender.setPort(port);
+		mailSender.setUsername(username);
+		mailSender.setPassword(password);
+		mailSender.setDefaultEncoding("UTF-8");
+		mailSender.setJavaMailProperties(getMailProperties());
+
+		return mailSender;
+	}
+
+	private Properties getMailProperties() {
+		Properties properties = new Properties();
+		properties.put("mail.smtp.auth", auth);
+		properties.put("mail.smtp.starttls.enable", starttlsEnable);
+		properties.put("mail.smtp.starttls.required", starttlsRequired);
+		properties.put("mail.smtp.connectiontimeout", connectionTimeout);
+		properties.put("mail.smtp.timeout", timeout);
+		properties.put("mail.smtp.writetimeout", writeTimeout);
+
+		return properties;
+	}
+}

--- a/src/main/java/excluz/excluz/auth/config/SecurityConfig.java
+++ b/src/main/java/excluz/excluz/auth/config/SecurityConfig.java
@@ -65,6 +65,7 @@ public class SecurityConfig {
 					"/oauth/kakao",
 					"/oauth/kakao/**",
 					"/kakao/**",
+					"api/v1/email/**",
 					// 일반 유저
 					"/api/v1/users/{userId}",
 					// 아이템

--- a/src/main/java/excluz/excluz/common/entity/EmailVerify.java
+++ b/src/main/java/excluz/excluz/common/entity/EmailVerify.java
@@ -1,0 +1,35 @@
+package excluz.excluz.common.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "email_verifys")
+@NoArgsConstructor
+public class EmailVerify {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Integer id;
+
+	@Column(nullable = false, unique = true)
+	private String email;
+
+	@Column(nullable = false)
+	private Boolean emailStatus;
+
+	public EmailVerify(String email) {
+		this.email = email;
+		this.emailStatus = false;
+	}
+
+	public void updateEmailStatus(Boolean emailStatus) {this.emailStatus = emailStatus;}
+}

--- a/src/main/java/excluz/excluz/common/entity/EmailVerify.java
+++ b/src/main/java/excluz/excluz/common/entity/EmailVerify.java
@@ -24,12 +24,12 @@ public class EmailVerify {
 	private String email;
 
 	@Column(nullable = false)
-	private Boolean emailStatus;
+	private Boolean isVerified;
 
 	public EmailVerify(String email) {
 		this.email = email;
-		this.emailStatus = false;
+		this.isVerified = false;
 	}
 
-	public void updateEmailStatus(Boolean emailStatus) {this.emailStatus = emailStatus;}
+	public void updateEmailStatus(Boolean emailStatus) {this.isVerified = emailStatus;}
 }

--- a/src/main/java/excluz/excluz/common/exception/error/ErrorCode.java
+++ b/src/main/java/excluz/excluz/common/exception/error/ErrorCode.java
@@ -18,6 +18,9 @@ public enum ErrorCode {
 	PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
 	EMAIL_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 사용중인 이메일입니다."),
 	PASSWORD_RE_ENTER_PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "비밀번호와 재입력 비밀번호가 일치하지 않습니다."),
+	FAIL_SEND_EMAIL(HttpStatus.BAD_REQUEST, "인증 코드 발송에 실패하였습니다."),
+	EMAIL_VERIFICATION_NOT_REQUESTED(HttpStatus.BAD_REQUEST, "이메일 인증을 먼저 진행해 주세요"),
+	EMAIL_VERIFICATION_NOT_COMPLETED(HttpStatus.BAD_REQUEST, "이메일 인증이 완료 되지 않았습니다."),
 
 	// 아이템 관련 예외 코드
 	ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "조회되는 아이템 정보가 없습니다."),

--- a/src/main/java/excluz/excluz/domain/emailVerification/controller/EmailController.java
+++ b/src/main/java/excluz/excluz/domain/emailVerification/controller/EmailController.java
@@ -1,0 +1,35 @@
+package excluz.excluz.domain.emailVerification.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import excluz.excluz.domain.emailVerification.dto.EmailVerifyRequestDto;
+import excluz.excluz.domain.emailVerification.service.EmailService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/v1/email")
+public class EmailController {
+
+	private final EmailService emailService;
+
+	@PostMapping("/send")
+	public ResponseEntity<Void> emailSend(@RequestBody EmailVerifyRequestDto emailVerify) {
+		log.info("이메일 발송 로직 작동");
+		emailService.sendEmail(emailVerify.getEmail());
+		return ResponseEntity.ok().build();
+	}
+
+	@PostMapping("/verify")
+	public ResponseEntity<Boolean> emailVerify(@RequestBody EmailVerifyRequestDto emailVerify) {
+		log.info("이메일 인증 로직 작동");
+		boolean isVerify = emailService.verifyEmailCode(emailVerify.getEmail(), emailVerify.getVerifyCode());
+		return ResponseEntity.ok(isVerify);
+	}
+}

--- a/src/main/java/excluz/excluz/domain/emailVerification/controller/EmailController.java
+++ b/src/main/java/excluz/excluz/domain/emailVerification/controller/EmailController.java
@@ -19,9 +19,9 @@ public class EmailController {
 
 	private final EmailService emailService;
 
-	@PostMapping("/send")
+	@PostMapping("/sending")
 	public ResponseEntity<Void> emailSend(@RequestBody EmailVerifyRequestDto emailVerify) {
-		log.info("이메일 발송 로직 작동");
+		log.info("이메일 코드 발송 로직 작동");
 		emailService.sendEmail(emailVerify.getEmail());
 		return ResponseEntity.ok().build();
 	}

--- a/src/main/java/excluz/excluz/domain/emailVerification/dto/EmailVerifyRequestDto.java
+++ b/src/main/java/excluz/excluz/domain/emailVerification/dto/EmailVerifyRequestDto.java
@@ -1,0 +1,11 @@
+package excluz.excluz.domain.emailVerification.dto;
+
+import lombok.Data;
+
+@Data
+public class EmailVerifyRequestDto {
+
+	private String email;
+
+	private String verifyCode;
+}

--- a/src/main/java/excluz/excluz/domain/emailVerification/repository/EmailVerifyRepository.java
+++ b/src/main/java/excluz/excluz/domain/emailVerification/repository/EmailVerifyRepository.java
@@ -1,0 +1,12 @@
+package excluz.excluz.domain.emailVerification.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import excluz.excluz.common.entity.EmailVerify;
+
+public interface EmailVerifyRepository extends JpaRepository<EmailVerify, Integer> {
+
+	Optional<EmailVerify> findByEmail(String email);
+}

--- a/src/main/java/excluz/excluz/domain/emailVerification/service/EmailService.java
+++ b/src/main/java/excluz/excluz/domain/emailVerification/service/EmailService.java
@@ -1,0 +1,133 @@
+package excluz.excluz.domain.emailVerification.service;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ThreadLocalRandom;
+
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
+import org.thymeleaf.templatemode.TemplateMode;
+import org.thymeleaf.templateresolver.ClassLoaderTemplateResolver;
+
+import excluz.excluz.common.entity.EmailVerify;
+import excluz.excluz.common.exception.BadRequestException;
+import excluz.excluz.common.exception.error.ErrorCode;
+import excluz.excluz.domain.emailVerification.repository.EmailVerifyRepository;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class EmailService {
+
+	private final EmailVerifyRepository emailVerifyRepository;
+
+
+	private static class CodeData {
+		String code;
+		long expiry;
+
+		CodeData(String code, long expiry) {
+			this.code = code;
+			this.expiry = expiry;
+		}
+	}
+
+	private final JavaMailSender javaMailSender;
+	private static final String senderEmail = "excluzofficial@gmail.com";
+	// 이메일을 key로, CodeData를 value로 저장하는 in-memory Map
+	private static final Map<String, CodeData> codeMap = new ConcurrentHashMap<>();
+	private static final long VALIDITY_DURATION = 300_000;
+
+	// 인증코드 생성 기능
+	private String createCode() {
+
+		// 이메일 인증 코드 길이 수
+		int codeLength = 6;
+
+		// ThreadLocalRandom을 사용하여 '0'(48) 부터 'z'(122) 사이의 값의 코드를 생성함
+		return ThreadLocalRandom.current()
+			.ints(48, 123)
+			.filter(i -> (i >= 48 && i <= 57) || // 숫자 0 - 9
+				(i >= 65 && i <= 90) || // 대문자 A - Z
+				(i >= 97 && i <= 122)) // 소문자 a - z
+			.limit(codeLength)
+			.collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
+			.toString();
+	}
+
+	private String setContext(String code) {
+		Context context = new Context(); // 템플릿 내에서 사용할 변수(데이터)를 저장하는 객체
+		TemplateEngine templateEngine = new TemplateEngine(); // 템플릿 파일을 처리(렌더링)하는 핵심 엔진 객체
+		ClassLoaderTemplateResolver templateResolver = new ClassLoaderTemplateResolver(); // 클래스 로더를 이용해서 탬플릿을 찾는 리졸버
+
+		context.setVariable("code", code); // 템플릿에서 사용할 변수 "code"에 전달받은 code 값을 넣는 로직
+
+		// 리졸버 설정
+		// prefix, suffix는 템플릿의 경로를 지정 하는 로직
+		templateResolver.setPrefix("templates/");
+		templateResolver.setSuffix(".html");
+		templateResolver.setTemplateMode(TemplateMode.HTML);
+		templateResolver.setCacheable(false);
+
+		templateEngine.setTemplateResolver(templateResolver);
+
+		return templateEngine.process("email", context);
+	}
+
+	// 이메일 폼 생성
+	private MimeMessage createEmailForm(String email, String authCode) throws MessagingException {
+		MimeMessage message = javaMailSender.createMimeMessage();
+		message.addRecipients(MimeMessage.RecipientType.TO, email);
+		message.setSubject("Excluz 이메일 인증 코드 입니다.");
+		message.setFrom(senderEmail);
+		message.setText(setContext(authCode), "utf-8", "html");
+
+		return message;
+	}
+
+	// 인증코드 이메일 발송
+	public void sendEmail(String email) {
+		codeMap.remove(email);
+		String newCode = createCode();
+		long expiryTime = System.currentTimeMillis() + VALIDITY_DURATION;
+		codeMap.put(email, new CodeData(newCode, expiryTime));
+
+		try {
+			MimeMessage message = createEmailForm(email, newCode);
+			javaMailSender.send(message);
+		} catch (MessagingException e) {
+			throw new BadRequestException(ErrorCode.FAIL_SEND_EMAIL);
+		}
+	}
+
+	@Transactional
+	public boolean verifyEmailCode(String email, String code) {
+		CodeData data = codeMap.get(email);
+
+		// 인증 코드가 없거나 만료된 경우
+		if (data == null || System.currentTimeMillis() > data.expiry) {
+			codeMap.remove(email);
+			return false;
+		}
+
+		// 입력한 코드가 저장된 코드와 일치하는 경우
+		if (data.code.equals(code)) {
+			codeMap.remove(email);
+
+			// 이메일 인증 상태 저장 (EmailVerify 테이블 활용)
+			EmailVerify emailVerify = emailVerifyRepository
+				.findByEmail(email)
+				.orElseGet(() -> new EmailVerify(email)); // 없으면 새로 생성
+			emailVerify.updateEmailStatus(true);
+			emailVerifyRepository.save(emailVerify);
+
+			return true;
+		}
+		return false;
+	}
+}

--- a/src/main/java/excluz/excluz/domain/streamer/service/StreamerService.java
+++ b/src/main/java/excluz/excluz/domain/streamer/service/StreamerService.java
@@ -8,10 +8,12 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import excluz.excluz.auth.util.JwtUtil;
+import excluz.excluz.common.entity.EmailVerify;
 import excluz.excluz.common.entity.Streamer;
 import excluz.excluz.common.exception.BadRequestException;
 import excluz.excluz.common.exception.NotFoundException;
 import excluz.excluz.common.exception.error.ErrorCode;
+import excluz.excluz.domain.emailVerification.repository.EmailVerifyRepository;
 import excluz.excluz.domain.streamer.dto.request.StreamerLoginRequestDto;
 import excluz.excluz.domain.streamer.dto.request.StreamerSignupRequestDto;
 import excluz.excluz.domain.streamer.dto.request.StreamerUpdateRequestDto;
@@ -27,12 +29,21 @@ public class StreamerService {
 
 	private final StreamerRepository streamerRepository;
 	private final PasswordEncoder passwordEncoder;
+	private final EmailVerifyRepository emailVerifyRepository;
 	private final JwtUtil jwtUtil;
 
 	@Transactional
 	public StreamerResponseDto streamerSignup(StreamerSignupRequestDto signupRequestDto) {
 		if (!signupRequestDto.getPassword().equals(signupRequestDto.getReEnterPassword())) {
 			throw new BadRequestException(ErrorCode.PASSWORD_MISMATCH);
+		}
+
+		EmailVerify emailVerify = emailVerifyRepository
+			.findByEmail(signupRequest.getEmail())
+			.orElseThrow(() -> new BadRequestException(ErrorCode.EMAIL_VERIFICATION_NOT_REQUESTED));
+
+		if (!emailVerify.getEmailStatus()) {
+			throw new BadRequestException(ErrorCode.EMAIL_VERIFICATION_NOT_COMPLETED);
 		}
 
 		String encodedPassword = passwordEncoder.encode(signupRequestDto.getPassword());

--- a/src/main/java/excluz/excluz/domain/user/service/UserService.java
+++ b/src/main/java/excluz/excluz/domain/user/service/UserService.java
@@ -7,10 +7,12 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import excluz.excluz.auth.util.JwtUtil;
+import excluz.excluz.common.entity.EmailVerify;
 import excluz.excluz.common.entity.User;
 import excluz.excluz.common.exception.BadRequestException;
 import excluz.excluz.common.exception.NotFoundException;
 import excluz.excluz.common.exception.error.ErrorCode;
+import excluz.excluz.domain.emailVerification.repository.EmailVerifyRepository;
 import excluz.excluz.domain.user.dto.request.UpdateMyProfileRequestDto;
 import excluz.excluz.domain.user.dto.request.UpdatePasswordRequestDto;
 import excluz.excluz.domain.user.dto.request.UserLoginRequestDto;
@@ -32,6 +34,7 @@ public class UserService {
 	private final UserRepository userRepository;
 	private final PasswordEncoder passwordEncoder;
 	private final JwtUtil jwtUtil;
+	private final EmailVerifyRepository emailVerifyRepository;
 
 	// 유저 회원가입
 	public UserSignupResponseDto userSignup(UserSignupRequestDto signupRequest) {
@@ -46,8 +49,13 @@ public class UserService {
 			throw new BadRequestException(ErrorCode.EMAIL_ALREADY_EXISTS);
 		}
 
-		// 리퀘스트 요청에 들어온 비밀번호와 재확인 비밀번호가 일치 하지 않을 시 예외
-		matchPassword(signupRequest.getPassword(), signupRequest.getReEnterPassword());
+		EmailVerify emailVerify = emailVerifyRepository
+			.findByEmail(signupRequest.getEmail())
+			.orElseThrow(() -> new BadRequestException(ErrorCode.EMAIL_VERIFICATION_NOT_REQUESTED));
+
+		if (!emailVerify.getIsVerified()) {
+			throw new BadRequestException(ErrorCode.EMAIL_VERIFICATION_NOT_COMPLETED);
+		}
 
 		// 비밀번호 해싱 처리
 		String bcryptPassword = passwordEncoder.encode(signupRequest.getPassword());
@@ -88,9 +96,6 @@ public class UserService {
 
 		// 유저 정보를 userId 로 조회
 		User user = userProfile(userId);
-
-		// 리퀘스트 요청에 들어온 비밀번호와 재확인 비밀번호가 일치 하지 않을 시 예외
-		matchPassword(userWithdrawRequest.getPassword(), userWithdrawRequest.getReEnterPassword());
 
 		// 비밀번호 검증 로직
 		validatePassword(userWithdrawRequest.getPassword(), user.getPassword());
@@ -149,9 +154,6 @@ public class UserService {
 		// 비밀번호 검증 로직
 		validatePassword(updatePasswordRequest.getOldPassword(), user.getPassword());
 
-		// 새로운 비밀번호와 재입력 비밀번호 검증 로직
-		matchPassword(updatePasswordRequest.getNewPassword(), updatePasswordRequest.getReEnterPassword());
-
 		// 새로운 비밀번호가 이전에 사용하던 비밀번호와 같을 경우 예외처리
 		if(passwordEncoder.matches(updatePasswordRequest.getNewPassword(), user.getPassword())) {
 			throw new BadRequestException(ErrorCode.INVALID_PASSWORD);
@@ -169,13 +171,6 @@ public class UserService {
 	public void validatePassword(String rawPassword, String encodedPassword) {
 		if (!passwordEncoder.matches(rawPassword, encodedPassword)) {
 			throw new BadRequestException(ErrorCode.PASSWORD_MISMATCH);
-		}
-	}
-
-	// 기타 메서드(비밀번호와 재입력 비밀번호 검증)
-	public void matchPassword(String inputPassword, String reEnterPassword) {
-		if(!inputPassword.equals(reEnterPassword)) {
-			throw new BadRequestException(ErrorCode.PASSWORD_RE_ENTER_PASSWORD_MISMATCH);
 		}
 	}
 

--- a/src/main/resources/templates/email.html
+++ b/src/main/resources/templates/email.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<body>
+<div style="margin:120px">
+    <div style="margin-bottom: 10px">
+        <h1 style="text-align: center;">인증 코드 메일입니다.</h1>
+        <br/>
+        <h3 style="text-align: center;"> 아래 코드를 사이트에 입력해주십시오</h3>
+    </div>
+    <div style="text-align: center;">
+        <h2 style="color: black;" th:text="${code}"></h2>
+    </div>
+    <br/>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/emailSend.html
+++ b/src/main/resources/templates/emailSend.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>비밀번호 인증</title>
+</head>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
+<script type="text/javascript">
+    function sendNumber() {
+        $("#mail_number").css("display", "block");
+        $.ajax({
+            url: "/api/v1/email/send",
+            type: "post",
+            dataType: "json",
+            data: {"mail": $("#mail").val()},
+            success: function (data) {
+                alert("인증번호 발송");
+                $("#Confirm").attr("value", data);
+            }
+        });
+    }
+
+    function confirmNumber() {
+        let mail = $("#mail").val();
+        let number = $("#number").val();
+
+        $.ajax({
+            url: "/api/v1/email/verify",
+            type: "post",
+            dataType: "json",
+            data: {"mail": mail, "verifyCode": number},
+            success: function (data, status, xhr) {
+                console.log(status);
+            }
+        });
+    }
+</script>
+<body>
+<div id="mail_input" name="mail_input">
+    <input type="text" name="mail" id="mail" placeholder="이메일 입력">
+    <button type="button" id="sendBtn" name="sendBtn" onclick="sendNumber()">인증번호</button>
+</div>
+<br>
+<div id="mail_number" name="mail_number" style="display: none">
+    <input type="text" name="number" id="number" placeholder="인증번호 입력">
+    <button type="button" name="confirmBtn" id="confirmBtn" onclick="confirmNumber()">이메일 인증</button>
+</div>
+<br>
+<input type="text" id="Confirm" name="Confirm" style="display: none" value="">
+</body>
+</html>


### PR DESCRIPTION
## 목적
이메일 검증 관련 로직이 없음을 파악 후 실 서비스를 가정하에 보안적 이슈가 있음을 파악 문제를 해결 하기 위해 이메일 인증 로직을 구현

## 변경점
- Spring security에 emailVerify관련 URI 추가
- 이메일 인증 엔티티 추가 및 새로운 컨트롤러, 서비스, DTO, 레포지토리 생성
- 이메일 발송시에 사용될 Tymleaf Html 추가(email.html)

## 리뷰어에게
- 서비스 로직에 궁금하신 점이나 개선하면 좋겠다 하시는 부분을 잡아주시면 좋을 거 같습니다.