### PR TITLE
🚑  refactor: edit EmailService

### DIFF
--- a/src/main/java/excluz/excluz/common/entity/EmailVerify.java
+++ b/src/main/java/excluz/excluz/common/entity/EmailVerify.java
@@ -6,7 +6,6 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -31,5 +30,5 @@ public class EmailVerify {
 		this.isVerified = false;
 	}
 
-	public void updateEmailStatus(Boolean emailStatus) {this.isVerified = emailStatus;}
+	public void updateEmailStatus(Boolean isVerified) {this.isVerified = isVerified;}
 }

--- a/src/main/java/excluz/excluz/domain/emailVerification/service/EmailService.java
+++ b/src/main/java/excluz/excluz/domain/emailVerification/service/EmailService.java
@@ -93,9 +93,16 @@ public class EmailService {
 	// 인증코드 이메일 발송
 	public void sendEmail(String email) {
 		codeMap.remove(email);
+
+		// 인증 코드 발송후 테이블에 인증 상태를 저장하는 로직
+		EmailVerify sendCodeEmail = new EmailVerify(email);
+		emailVerifyRepository.save(sendCodeEmail);
+
+		// 새로운 코드 생성
 		String newCode = createCode();
 		long expiryTime = System.currentTimeMillis() + VALIDITY_DURATION;
 		codeMap.put(email, new CodeData(newCode, expiryTime));
+
 
 		try {
 			MimeMessage message = createEmailForm(email, newCode);


### PR DESCRIPTION
## 목적
새로운 유저가 이메일 일증을 발송 할 시 DB에 인증여부 데이터가 생기지 않는 이슈를 해결

## 변경점
테스트중 삭제후 복구해두었던 코드가 릴리스에 반영이 안된 것을 확인 누락된 코드를 복구