### PR TITLE
✨ feat: Add settlement-related APIs

### DIFF
--- a/src/main/java/excluz/excluz/common/entity/StoreSettlement.java
+++ b/src/main/java/excluz/excluz/common/entity/StoreSettlement.java
@@ -25,7 +25,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "store_settlement")
 @NoArgsConstructor
 @EntityListeners(AuditingEntityListener.class)
-public class StoreSettlement extends BaseEntity{
+public class StoreSettlement extends BaseEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -69,14 +69,14 @@ public class StoreSettlement extends BaseEntity{
 		LocalDateTime startDate,
 		LocalDateTime endDate
 	) {
-		this.storeId=storeId;
-		this.totalRevenue=totalRevenue;
-		this.platformFeeRate= platformFeeRate;
-		this.settlementAmount=settlementAmount;
-		this.settlementStatus=SettlementStatus.WAITING;
-		this.settlementPeriod=settlementPeriod;
-		this.startDate=startDate;
-		this.endDate=endDate;
+		this.storeId = storeId;
+		this.totalRevenue = totalRevenue;
+		this.platformFeeRate = platformFeeRate;
+		this.settlementAmount = settlementAmount;
+		this.settlementStatus = SettlementStatus.WAITING;
+		this.settlementPeriod = settlementPeriod;
+		this.startDate = startDate;
+		this.endDate = endDate;
 	}
 
 	public void updateStoreSettlement(
@@ -87,5 +87,9 @@ public class StoreSettlement extends BaseEntity{
 		if (totalRevenue != null) this.totalRevenue = totalRevenue;
 		if (platformFeeRate != null) this.platformFeeRate = platformFeeRate;
 		if (settlementAmount != null) this.settlementAmount = settlementAmount;
+	}
+
+	public void updateSettlementStatus(SettlementStatus newStatus) {
+		this.settlementStatus = newStatus;
 	}
 }

--- a/src/main/java/excluz/excluz/common/exception/BusinessException.java
+++ b/src/main/java/excluz/excluz/common/exception/BusinessException.java
@@ -1,0 +1,9 @@
+package excluz.excluz.common.exception;
+
+import excluz.excluz.common.exception.error.ErrorCode;
+
+public class BusinessException extends CustomRuntimeException {
+	public BusinessException(ErrorCode errorCode) {
+		super(errorCode);
+	}
+}

--- a/src/main/java/excluz/excluz/common/exception/error/ErrorCode.java
+++ b/src/main/java/excluz/excluz/common/exception/error/ErrorCode.java
@@ -36,6 +36,13 @@ public enum ErrorCode {
 	STORE_NOT_MATCH(HttpStatus.BAD_REQUEST, "스토어에 대한 권한이 없습니다."),
 	DUPLICATE_REGISTRATION_NUMBER(HttpStatus.CONFLICT, "다른 스토어와 중복되는 사업자 등록번호입니다."),
 	STORE_ALREADY_EXIST(HttpStatus.CONFLICT, "운영중인 스토어가 이미 존재합니다."),
+	PERIOD_NOT_MATCH(HttpStatus.BAD_REQUEST, "잘못된 기간(period) 값입니다."),
+
+	// 정산 관련 예외 코드
+	SETTLEMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "정산 기록이 없습니다."),
+	SETTLEMENT_STATUS_NOT_MATCH(HttpStatus.BAD_REQUEST, "잘못된 정산 상태(settlementStatus) 값입니다."),
+	INVALID_SETTLEMENT_STATUS_TRANSITION(HttpStatus.BAD_REQUEST, "현재 상태 이전으로 변경할 수 없습니다."),
+	SETTLEMENT_ALREADY_COMPLETED(HttpStatus.BAD_REQUEST, "정산이 완료된 건은 상태변경이 불가합니다."),
 
 	// 포인트 관련 예외 코드
 	POINT_NOT_FOUND(HttpStatus.NOT_FOUND, "포인트를 충전해주세요."),

--- a/src/main/java/excluz/excluz/domain/store/storeRevenue/enums/RevenuePeriod.java
+++ b/src/main/java/excluz/excluz/domain/store/storeRevenue/enums/RevenuePeriod.java
@@ -3,15 +3,13 @@ package excluz.excluz.domain.store.storeRevenue.enums;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 
+import excluz.excluz.common.exception.BadRequestException;
+import excluz.excluz.common.exception.error.ErrorCode;
+
 public enum RevenuePeriod {
-    MINUTE_1(ChronoUnit.MINUTES, 1),
-    MINUTE_2(ChronoUnit.MINUTES, 2),
-    MINUTE_10(ChronoUnit.MINUTES, 10),
-    HOUR_1(ChronoUnit.HOURS, 1),
-    DAY_1(ChronoUnit.DAYS, 1),
-    WEEK_1(ChronoUnit.WEEKS, 1),
-    MONTH_1(ChronoUnit.MONTHS, 1),
-    YEAR_1(ChronoUnit.YEARS, 1);
+    DAY(ChronoUnit.DAYS, 1),
+    MONTH(ChronoUnit.MONTHS, 1),
+    YEAR(ChronoUnit.YEARS, 1);
 
     private final ChronoUnit unit;  // 시간 단위 (분, 시간, 일 등)
     private final long amount;       // 해당 단위의 기간 (1분, 2분, 1시간 등)
@@ -51,5 +49,17 @@ public enum RevenuePeriod {
      */
     private boolean isMinuteOrHour() {
         return unit == ChronoUnit.MINUTES || unit == ChronoUnit.HOURS;
+    }
+
+    /**
+     * 대소문자 구분 없이 Enum 값 변환
+     */
+    public static RevenuePeriod valueOfIgnoreCase(String period) {
+        for (RevenuePeriod revenuePeriod : values()) {
+            if (revenuePeriod.name().equalsIgnoreCase(period)) {
+                return revenuePeriod;
+            }
+        }
+        throw new BadRequestException(ErrorCode.PERIOD_NOT_MATCH);
     }
 }

--- a/src/main/java/excluz/excluz/domain/store/storeSettlement/controller/StoreSettlementV2Controller.java
+++ b/src/main/java/excluz/excluz/domain/store/storeSettlement/controller/StoreSettlementV2Controller.java
@@ -1,0 +1,79 @@
+package excluz.excluz.domain.store.storeSettlement.controller;
+
+import java.time.LocalDateTime;
+
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import excluz.excluz.auth.util.SecurityContextUtil;
+import excluz.excluz.domain.store.storeSettlement.dto.request.StoreSettlementStatusRequestDto;
+import excluz.excluz.domain.store.storeSettlement.dto.response.StoreSettlementResponseDto;
+import excluz.excluz.domain.store.storeSettlement.dto.response.StoreSettlementResponseDtoList;
+import excluz.excluz.domain.store.storeSettlement.service.StoreSettlementV2Service;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v2/settlements")
+public class StoreSettlementV2Controller {
+
+	private final StoreSettlementV2Service settlementV2Service;
+
+	@GetMapping("/me")
+	@PreAuthorize("hasRole('STREAMER')")
+	public ResponseEntity<StoreSettlementResponseDtoList> getOwnSettlementList(
+		@RequestParam(required = false) Integer settlementId,
+		@RequestParam(required = false)
+		@DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime startDate,
+		@RequestParam(required = false)
+		@DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime endDate,
+		@RequestParam(required = false) String period,
+		@RequestParam(defaultValue = "0") Integer page,
+		@RequestParam(defaultValue = "20") Integer size
+	) {
+		Integer streamerId = SecurityContextUtil.getUserOrStreamerId();
+
+		StoreSettlementResponseDtoList settlementResponseList = settlementV2Service.getOwnSettlementList(
+			streamerId, settlementId, startDate, endDate, period, page, size);
+
+		return new ResponseEntity<>(settlementResponseList, HttpStatus.OK);
+	}
+
+	@GetMapping()
+	@PreAuthorize("hasRole('ADMIN')")
+	public ResponseEntity<StoreSettlementResponseDtoList> getSettlementList(
+		@RequestParam(required = false) Integer settlementId,
+		@RequestParam(required = false) Integer storeId,
+		@RequestParam(required = false)
+		@DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime startDate,
+		@RequestParam(required = false)
+		@DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime endDate,
+		@RequestParam(required = false) String period,
+		@RequestParam(defaultValue = "0") Integer page,
+		@RequestParam(defaultValue = "20") Integer size
+	) {
+		StoreSettlementResponseDtoList settlementResponseList = settlementV2Service.getSettlementList(
+			storeId, settlementId, startDate, endDate, period, page, size);
+
+		return new ResponseEntity<>(settlementResponseList, HttpStatus.OK);
+	}
+
+	@PatchMapping()
+	@PreAuthorize("hasRole('ADMIN')")
+	public ResponseEntity<StoreSettlementResponseDto> updateSettlementStatus(
+		@RequestParam Integer settlementId,
+		@RequestBody StoreSettlementStatusRequestDto statusRequestDto
+	) {
+		StoreSettlementResponseDto responseDto = settlementV2Service.updateSettlementStatus(settlementId, statusRequestDto);
+
+		return new ResponseEntity<>(responseDto, HttpStatus.OK);
+	}
+}

--- a/src/main/java/excluz/excluz/domain/store/storeSettlement/dto/request/StoreSettlementStatusRequestDto.java
+++ b/src/main/java/excluz/excluz/domain/store/storeSettlement/dto/request/StoreSettlementStatusRequestDto.java
@@ -1,0 +1,15 @@
+package excluz.excluz.domain.store.storeSettlement.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class StoreSettlementStatusRequestDto {
+
+	private String settlementStatus;
+
+	public StoreSettlementStatusRequestDto(String settlementStatus) {
+		this.settlementStatus = settlementStatus;
+	}
+}

--- a/src/main/java/excluz/excluz/domain/store/storeSettlement/dto/response/StoreSettlementResponseDto.java
+++ b/src/main/java/excluz/excluz/domain/store/storeSettlement/dto/response/StoreSettlementResponseDto.java
@@ -1,0 +1,42 @@
+package excluz.excluz.domain.store.storeSettlement.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.querydsl.core.annotations.QueryProjection;
+
+import excluz.excluz.common.entity.StoreSettlement;
+import excluz.excluz.domain.store.storeRevenue.enums.RevenuePeriod;
+import excluz.excluz.domain.store.storeSettlement.enums.FeeRate;
+import excluz.excluz.domain.store.storeSettlement.enums.SettlementStatus;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class StoreSettlementResponseDto {
+
+	private Integer id;
+	private Integer storeId;
+	private FeeRate platformFeeRate;
+	private Long settlementAmount;
+	private SettlementStatus settlementStatus;
+	private RevenuePeriod settlementPeriod;
+	private LocalDateTime startDate;
+	private LocalDateTime endDate;
+	private LocalDateTime createdAt;
+	private LocalDateTime updatedAt;
+
+	@QueryProjection
+	public StoreSettlementResponseDto(StoreSettlement storeSettlement) {
+		this.id = storeSettlement.getId();
+		this.storeId = storeSettlement.getStoreId();
+		this.platformFeeRate = storeSettlement.getPlatformFeeRate();
+		this.settlementAmount = storeSettlement.getSettlementAmount();
+		this.settlementStatus = storeSettlement.getSettlementStatus();
+		this.settlementPeriod = storeSettlement.getSettlementPeriod();
+		this.startDate = storeSettlement.getStartDate();
+		this.endDate = storeSettlement.getEndDate();
+		this.createdAt = storeSettlement.getCreatedAt();
+		this.updatedAt = storeSettlement.getUpdatedAt();
+	}
+}

--- a/src/main/java/excluz/excluz/domain/store/storeSettlement/dto/response/StoreSettlementResponseDtoList.java
+++ b/src/main/java/excluz/excluz/domain/store/storeSettlement/dto/response/StoreSettlementResponseDtoList.java
@@ -1,0 +1,19 @@
+package excluz.excluz.domain.store.storeSettlement.dto.response;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import excluz.excluz.common.entity.StoreSettlement;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class StoreSettlementResponseDtoList {
+
+	private List<StoreSettlementResponseDto> settlementResponseList;
+
+	public StoreSettlementResponseDtoList(List<StoreSettlementResponseDto> settlementResponseList) {
+		this.settlementResponseList=settlementResponseList;
+	}
+}

--- a/src/main/java/excluz/excluz/domain/store/storeSettlement/enums/SettlementStatus.java
+++ b/src/main/java/excluz/excluz/domain/store/storeSettlement/enums/SettlementStatus.java
@@ -1,5 +1,11 @@
 package excluz.excluz.domain.store.storeSettlement.enums;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import excluz.excluz.common.exception.BadRequestException;
+import excluz.excluz.common.exception.error.ErrorCode;
 import lombok.Getter;
 
 @Getter
@@ -13,5 +19,25 @@ public enum SettlementStatus {
 
 	SettlementStatus(String description) {
 		this.description = description;
+	}
+
+	public static SettlementStatus valueOfIgnoreCase(String status) {
+		for (SettlementStatus settlementStatus : values()) {
+			if (settlementStatus.name().equalsIgnoreCase(status)) {
+				return settlementStatus;
+			}
+		}
+		throw new BadRequestException(ErrorCode.SETTLEMENT_STATUS_NOT_MATCH);
+	}
+
+	// 정산 상태 변경 유효성 체크 (WAITING -> HOLD/PROCESSING -> COMPLETED 순서로 변경 가능하며 이전 순서로 되돌아갈 수 없음)
+	public static boolean isValidStatusTransition(SettlementStatus currentStatus, SettlementStatus nextStatus) {
+		Map<SettlementStatus, List<SettlementStatus>> validTransition = Map.of(
+			SettlementStatus.WAITING, List.of(SettlementStatus.HOLD, SettlementStatus.PROCESSING),
+			SettlementStatus.HOLD, List.of(SettlementStatus.PROCESSING, SettlementStatus.COMPLETED),
+			SettlementStatus.PROCESSING, List.of(SettlementStatus.HOLD, SettlementStatus.COMPLETED)
+		);
+
+		return validTransition.getOrDefault(currentStatus, Collections.emptyList()).contains(nextStatus);
 	}
 }

--- a/src/main/java/excluz/excluz/domain/store/storeSettlement/repository/StoreSettlementRepository.java
+++ b/src/main/java/excluz/excluz/domain/store/storeSettlement/repository/StoreSettlementRepository.java
@@ -1,0 +1,8 @@
+package excluz.excluz.domain.store.storeSettlement.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import excluz.excluz.common.entity.StoreSettlement;
+
+public interface StoreSettlementRepository extends JpaRepository<StoreSettlement, Integer> {
+}

--- a/src/main/java/excluz/excluz/domain/store/storeSettlement/repository/StoreSettlementV2Repository.java
+++ b/src/main/java/excluz/excluz/domain/store/storeSettlement/repository/StoreSettlementV2Repository.java
@@ -1,0 +1,63 @@
+package excluz.excluz.domain.store.storeSettlement.repository;
+
+import static excluz.excluz.common.entity.QStoreSettlement.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import excluz.excluz.domain.store.storeRevenue.enums.RevenuePeriod;
+import excluz.excluz.domain.store.storeSettlement.dto.response.QStoreSettlementResponseDto;
+import excluz.excluz.domain.store.storeSettlement.dto.response.StoreSettlementResponseDto;
+
+@Repository
+public class StoreSettlementV2Repository {
+
+	private final JPAQueryFactory queryFactory;
+
+	public StoreSettlementV2Repository(JPAQueryFactory queryFactory) {
+		this.queryFactory = queryFactory;
+	}
+
+	public List<StoreSettlementResponseDto> findByPeriod(Integer storeId, Integer settlementId,
+		LocalDateTime startDate, LocalDateTime endDate, RevenuePeriod period, Integer page, Integer size) {
+		return queryFactory
+			.select(new QStoreSettlementResponseDto(storeSettlement))
+			.from(storeSettlement)
+			.where(
+				storeIdEq(storeId),
+				settlementIdEq(settlementId),
+				startDateEq(startDate),
+				endDateEq(endDate),
+				periodEq(period)
+			)
+			.orderBy(storeSettlement.id.asc())
+			.offset(page)
+			.limit(size)
+			.fetch();
+	}
+
+	private BooleanExpression storeIdEq(Integer storeId) {
+		return storeId != null ? storeSettlement.storeId.eq(storeId) : null;
+	}
+
+	private BooleanExpression settlementIdEq(Integer settlementId) {
+		return settlementId != null ? storeSettlement.id.eq(settlementId) : null;
+	}
+
+	private BooleanExpression startDateEq(LocalDateTime startDate) {
+		return startDate != null ? storeSettlement.startDate.goe(startDate) : null;
+	}
+
+	private BooleanExpression endDateEq(LocalDateTime endDate) {
+		return endDate != null ? storeSettlement.endDate.loe(endDate) : null;
+	}
+
+	private BooleanExpression periodEq(RevenuePeriod period) {
+		return period != null ? storeSettlement.settlementPeriod.eq(period) : null;
+	}
+}

--- a/src/main/java/excluz/excluz/domain/store/storeSettlement/service/StoreSettlementV2Service.java
+++ b/src/main/java/excluz/excluz/domain/store/storeSettlement/service/StoreSettlementV2Service.java
@@ -1,0 +1,83 @@
+package excluz.excluz.domain.store.storeSettlement.service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import excluz.excluz.common.entity.Store;
+import excluz.excluz.common.entity.StoreSettlement;
+import excluz.excluz.common.exception.BusinessException;
+import excluz.excluz.common.exception.NotFoundException;
+import excluz.excluz.common.exception.error.ErrorCode;
+import excluz.excluz.domain.store.store.repository.StoreRepository;
+import excluz.excluz.domain.store.storeRevenue.enums.RevenuePeriod;
+import excluz.excluz.domain.store.storeSettlement.dto.request.StoreSettlementStatusRequestDto;
+import excluz.excluz.domain.store.storeSettlement.dto.response.StoreSettlementResponseDto;
+import excluz.excluz.domain.store.storeSettlement.dto.response.StoreSettlementResponseDtoList;
+import excluz.excluz.domain.store.storeSettlement.enums.SettlementStatus;
+import excluz.excluz.domain.store.storeSettlement.repository.StoreSettlementRepository;
+import excluz.excluz.domain.store.storeSettlement.repository.StoreSettlementV2Repository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class StoreSettlementV2Service {
+
+	private StoreSettlementRepository settlementRepository;
+	private StoreSettlementV2Repository settlementV2Repository;
+	private StoreRepository storeRepository;
+
+	@Transactional(readOnly = true)
+	public StoreSettlementResponseDtoList getSettlementList(Integer storeId, Integer settlementId,
+		LocalDateTime startDate, LocalDateTime endDate, String periodStr, Integer page, Integer size
+	) {
+		RevenuePeriod period = RevenuePeriod.valueOfIgnoreCase(periodStr);
+
+		List<StoreSettlementResponseDto> responseDtoList = settlementV2Repository.findByPeriod(
+			storeId, settlementId, startDate, endDate, period, page, size);
+
+		if (responseDtoList.isEmpty()) {
+			throw new NotFoundException(ErrorCode.SETTLEMENT_NOT_FOUND);
+		}
+
+		return new StoreSettlementResponseDtoList(responseDtoList);
+	}
+
+	@Transactional(readOnly = true)
+	public StoreSettlementResponseDtoList getOwnSettlementList(Integer streamerId, Integer settlementId,
+		LocalDateTime startDate, LocalDateTime endDate, String periodStr, Integer page, Integer size
+	) {
+		Store store = storeRepository.findStoreWithStreamer(streamerId).orElseThrow(
+			() -> new NotFoundException(ErrorCode.STORE_NOT_FOUND)
+		);
+
+		return getSettlementList(store.getId(), settlementId, startDate, endDate, periodStr, page, size);
+	}
+
+	@Transactional
+	public StoreSettlementResponseDto updateSettlementStatus(Integer settlementId,
+		StoreSettlementStatusRequestDto statusRequestDto
+	) {
+		SettlementStatus status = SettlementStatus.valueOfIgnoreCase(statusRequestDto.getSettlementStatus());
+
+		StoreSettlement settlement = settlementRepository.findById(settlementId).orElseThrow(
+			() -> new NotFoundException(ErrorCode.SETTLEMENT_NOT_FOUND)
+		);
+
+		// 비즈니스 규칙: 정산 완료된 건은 상태 변경 불가
+		if (settlement.getSettlementStatus() == SettlementStatus.COMPLETED) {
+			throw new BusinessException(ErrorCode.SETTLEMENT_ALREADY_COMPLETED);
+		}
+
+		// 비즈니스 규칙: 현재 상태 이전 단계로 변경 불가
+		if (!SettlementStatus.isValidStatusTransition(settlement.getSettlementStatus(), status)) {
+			throw new BusinessException(ErrorCode.INVALID_SETTLEMENT_STATUS_TRANSITION);
+		}
+
+		settlement.updateSettlementStatus(status);
+
+		return new StoreSettlementResponseDto(settlement);
+	}
+}


### PR DESCRIPTION
## 목적
정산 관련 API 구현

## 변경점
- (스트리머/어드민) 전용 정산 조회  API 구현
- 정산 상태 변경 API 구현
- RevenuePeriod의 불필요한 enum 값 제거 