### PR TITLE
✨ feat: Add caching to getItemList

### DIFF
--- a/src/main/java/excluz/excluz/auth/config/SecurityConfig.java
+++ b/src/main/java/excluz/excluz/auth/config/SecurityConfig.java
@@ -73,6 +73,7 @@ public class SecurityConfig {
 					// 아이템
 					"/api/v1/items",
 					"/api/v2/items",
+					"/api/v3/items",
 					"/api/v1/items/{itemsId}",
 					// 스토어
 					"/api/v1/stores/{storeId}",

--- a/src/main/java/excluz/excluz/common/filter/LoggingService.java
+++ b/src/main/java/excluz/excluz/common/filter/LoggingService.java
@@ -15,7 +15,22 @@ public class LoggingService {
 	@Value("${slack.webhook-url}")
 	private String webhookUrl;
 
-	public void sendMessage(String title, String exceptionName, String requestURI, String method, String message){
+	public void sendMessage(String title, String exceptionName, String requestURI, String method, String message) {
+		// 에러 메세지 특수문자 처리
+		if (message == null || message.isEmpty()) {
+			message = "No error message provided";
+		} else {
+			message = message.replace("\n", " ") // 개행 문자 제거
+				.replace("\r", " ") // 개행 문자 제거
+				.replace("\"", "'") // 큰따옴표 → 작은따옴표로 변경
+				.replace("\\", ""); // 역슬래시 제거
+
+			// 메세지 길이 제한
+			if (message.length() > 3000) {
+				message = message.substring(0, 3000) + "... (생략됨)";
+			}
+		}
+
 		Slack slack = Slack.getInstance();
 		String payload = String.format(
 			"{\"text\": \"*🚨 %s 발생!*\\n" +
@@ -26,7 +41,7 @@ public class LoggingService {
 		);
 		try {
 			WebhookResponse response = slack.send(webhookUrl, payload);
-			log.info("slack 메시지 전송 상태: {}",response);
+			log.info("slack 메시지 전송 상태: {}", response);
 		} catch (Exception e) {
 			log.error("slack 메시지 발송 중 문제가 발생했습니다.");
 		}

--- a/src/main/java/excluz/excluz/domain/store/item/controller/ItemV1Controller.java
+++ b/src/main/java/excluz/excluz/domain/store/item/controller/ItemV1Controller.java
@@ -71,9 +71,10 @@ public class ItemV1Controller {
 		Pageable pageable,
 		@RequestParam(defaultValue = "0") Integer minPrice,
 		@RequestParam(defaultValue = "2147483647") Integer maxPrice,
-		@RequestParam(required = false) String itemName
+		@RequestParam(required = false) String itemName,
+		@RequestParam(required = false) Integer storeId
 	) {
-		GetItemListResponseDto responseDto = itemService.getItemList(pageable, minPrice, maxPrice, itemName);
+		GetItemListResponseDto responseDto = itemService.getItemList(pageable, minPrice, maxPrice, itemName, storeId);
 
 		return new ResponseEntity<>(responseDto, HttpStatus.OK);
 	}

--- a/src/main/java/excluz/excluz/domain/store/item/controller/ItemV2Controller.java
+++ b/src/main/java/excluz/excluz/domain/store/item/controller/ItemV2Controller.java
@@ -23,10 +23,11 @@ public class ItemV2Controller {
 		@RequestParam(defaultValue = "0") Integer minPrice,
 		@RequestParam(defaultValue = "2147483647") Integer maxPrice,
 		@RequestParam(required = false) String itemName,
+		@RequestParam(required = false) Integer storeId,
 		@RequestParam(required = false) Integer cursor,
 		@RequestParam(defaultValue = "20") int limit
 	) {
-		GetItemListResponseDtoV2 responseDto = itemV2Service.getItemList(minPrice, maxPrice, itemName, cursor, limit);
+		GetItemListResponseDtoV2 responseDto = itemV2Service.getItemList(minPrice, maxPrice, itemName, storeId, cursor, limit);
 		return new ResponseEntity<>(responseDto, HttpStatus.OK);
 	}
 }

--- a/src/main/java/excluz/excluz/domain/store/item/controller/ItemV3Controller.java
+++ b/src/main/java/excluz/excluz/domain/store/item/controller/ItemV3Controller.java
@@ -1,0 +1,34 @@
+package excluz.excluz.domain.store.item.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import excluz.excluz.domain.store.item.dto.response.GetItemListResponseDtoV2;
+import excluz.excluz.domain.store.item.service.ItemV2Service;
+import excluz.excluz.domain.store.item.service.ItemV3Service;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v3/items")
+public class ItemV3Controller {
+
+	private final ItemV3Service itemV3Service;
+
+	@GetMapping()
+	public ResponseEntity<GetItemListResponseDtoV2> getItemList(
+		@RequestParam(defaultValue = "0") Integer minPrice,
+		@RequestParam(defaultValue = "2147483647") Integer maxPrice,
+		@RequestParam(required = false) String itemName,
+		@RequestParam(required = false) Integer storeId,
+		@RequestParam(required = false) Integer cursor,
+		@RequestParam(defaultValue = "20") int limit
+	) {
+		GetItemListResponseDtoV2 responseDto = itemV3Service.getItemList(minPrice, maxPrice, itemName, storeId, cursor, limit);
+		return new ResponseEntity<>(responseDto, HttpStatus.OK);
+	}
+}

--- a/src/main/java/excluz/excluz/domain/store/item/repository/ItemRepository.java
+++ b/src/main/java/excluz/excluz/domain/store/item/repository/ItemRepository.java
@@ -18,12 +18,14 @@ public interface ItemRepository extends JpaRepository<Item, Integer> {
 		"AND (i.price >= :minPrice) " +
 		"AND (i.price <= :maxPrice) " +
 		"AND (i.isDeleted = FALSE ) " +
+		"AND (:storeId IS NULL OR (:storeId IS NOT NULL AND i.store.id = :storeId) ) " +
 		"ORDER BY i.id DESC")
 	Page<Item> findByPriceWithItemName(
 		Pageable pageable,
 		@Param("minPrice") Integer minPrice,
 		@Param("maxPrice") Integer maxPrice,
-		@Param("itemName") String itemName);
+		@Param("itemName") String itemName,
+		@Param("storeId") Integer StoreId);
 
 	@Query("SELECT i FROM Item i " +
 		"WHERE (i.id = :itemsId)" +

--- a/src/main/java/excluz/excluz/domain/store/item/repository/ItemV2Repository.java
+++ b/src/main/java/excluz/excluz/domain/store/item/repository/ItemV2Repository.java
@@ -20,7 +20,7 @@ public class ItemV2Repository{
 	}
 
 	public List<Item> findByPriceWithItemNameV2(
-		Integer minPrice, Integer maxPrice, String itemName, Integer cursor, int limit
+		Integer minPrice, Integer maxPrice, String itemName, Integer storeId, Integer cursor, int limit
 	) {
 
 		return queryFactory
@@ -30,6 +30,7 @@ public class ItemV2Repository{
 				item.price.goe(minPrice),
 				item.price.loe(maxPrice),
 				itemNameEq(itemName),
+				storeIdEq(storeId),
 				cursorEq(cursor)
 				)
 			.orderBy(item.id.desc())
@@ -47,5 +48,9 @@ public class ItemV2Repository{
 	// 커서 값이 있으면 id가 cursor보다 작은 값만 조회 (내림차순 정렬 기준)
 	private BooleanExpression cursorEq(Integer cursor) {
 		return cursor != null ? item.id.lt(cursor) : null;
+	}
+
+	private BooleanExpression storeIdEq(Integer storeId) {
+		return storeId != null ? item.store.id.eq(storeId) : null;
 	}
 }

--- a/src/main/java/excluz/excluz/domain/store/item/service/ItemService.java
+++ b/src/main/java/excluz/excluz/domain/store/item/service/ItemService.java
@@ -80,12 +80,14 @@ public class ItemService {
 	}
 
 	@Transactional(readOnly = true)
-	public GetItemListResponseDto getItemList(Pageable pageable,Integer minPrice, Integer maxPrice, String itemName) {
+	public GetItemListResponseDto getItemList(Pageable pageable,Integer minPrice, Integer maxPrice,
+		String itemName, Integer storeId
+	) {
 		if (!isValidPrice(minPrice,maxPrice)) {
 			throw new BadRequestException(ErrorCode.INVALID_ITEM_PRICE);
 		}
 
-		Page<Item> items = itemRepository.findByPriceWithItemName(pageable, minPrice, maxPrice, itemName);
+		Page<Item> items = itemRepository.findByPriceWithItemName(pageable, minPrice, maxPrice, itemName, storeId);
 		Page<ItemListResponseDto> responseDtoPage = items.map(ItemListResponseDto::from);
 
 		return new GetItemListResponseDto(minPrice, maxPrice, responseDtoPage);

--- a/src/main/java/excluz/excluz/domain/store/item/service/ItemV2Service.java
+++ b/src/main/java/excluz/excluz/domain/store/item/service/ItemV2Service.java
@@ -21,7 +21,7 @@ public class ItemV2Service {
 
 	@Transactional(readOnly = true)
 	public GetItemListResponseDtoV2 getItemList(
-		Integer minPrice, Integer maxPrice,	String itemName, Integer cursor, int limit
+		Integer minPrice, Integer maxPrice,	String itemName, Integer storeId, Integer cursor, int limit
 	) {
 		if (!isValidPrice(minPrice, maxPrice)) {
 			throw new BadRequestException(ErrorCode.INVALID_ITEM_PRICE);
@@ -29,7 +29,7 @@ public class ItemV2Service {
 
 		// 다음 페이지 존재 여부 확인
 		List<Item> itemList = itemV2Repository.findByPriceWithItemNameV2(
-			minPrice, maxPrice,	itemName, cursor, limit + 1);
+			minPrice, maxPrice,	itemName, storeId, cursor, limit + 1);
 
 		boolean hasNext = itemList.size() > limit;
 		if (hasNext) {

--- a/src/main/java/excluz/excluz/domain/store/item/service/ItemV3Service.java
+++ b/src/main/java/excluz/excluz/domain/store/item/service/ItemV3Service.java
@@ -1,0 +1,57 @@
+package excluz.excluz.domain.store.item.service;
+
+import java.util.List;
+
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import excluz.excluz.common.entity.Item;
+import excluz.excluz.common.exception.BadRequestException;
+import excluz.excluz.common.exception.error.ErrorCode;
+import excluz.excluz.domain.store.item.dto.response.GetItemListResponseDtoV2;
+import excluz.excluz.domain.store.item.dto.response.ItemListResponseDto;
+import excluz.excluz.domain.store.item.repository.ItemV2Repository;
+import lombok.AllArgsConstructor;
+
+@Service
+@AllArgsConstructor
+public class ItemV3Service {
+
+	private final ItemV2Repository itemV2Repository;
+
+	@Cacheable(value = "ITEM_LIST_CACHE",
+		key = "#cursor + '_' + #limit",
+		unless = "#result == null"
+	)
+	@Transactional(readOnly = true)
+	public GetItemListResponseDtoV2 getItemList(
+		Integer minPrice, Integer maxPrice,	String itemName, Integer storeId, Integer cursor, int limit
+	) {
+		if (!isValidPrice(minPrice, maxPrice)) {
+			throw new BadRequestException(ErrorCode.INVALID_ITEM_PRICE);
+		}
+
+		// 다음 페이지 존재 여부 확인
+		List<Item> itemList = itemV2Repository.findByPriceWithItemNameV2(
+			minPrice, maxPrice,	itemName, storeId, cursor, limit + 1);
+
+		boolean hasNext = itemList.size() > limit;
+		if (hasNext) {
+			itemList.remove(itemList.size() - 1); // 다음 페이지 확인용 추가 데이터 제거
+		}
+
+		// 다음 페이지가 있다면 마지막 아이템의 id를 nextCursor로 설정 (정렬 기준 = id 내림차순)
+		Integer nextCursor = hasNext ? itemList.get(itemList.size() - 1).getId() : null;
+
+		List<ItemListResponseDto> itemListResponseDtoList = itemList.stream()
+			.map(ItemListResponseDto::from)
+			.toList();
+
+		return new GetItemListResponseDtoV2(minPrice, maxPrice, itemListResponseDtoList, nextCursor);
+	}
+
+	private boolean isValidPrice(Integer minPrice, Integer maxPrice) {
+		return minPrice >= 0 && maxPrice >= 0 && (maxPrice >= minPrice);
+	}
+}

--- a/src/main/java/excluz/excluz/domain/store/item/service/ItemV3Service.java
+++ b/src/main/java/excluz/excluz/domain/store/item/service/ItemV3Service.java
@@ -21,7 +21,9 @@ public class ItemV3Service {
 	private final ItemV2Repository itemV2Repository;
 
 	@Cacheable(value = "ITEM_LIST_CACHE",
-		key = "#cursor + '_' + #limit",
+		key = "(#storeId != null ? #storeId : 'null') + '_' +"
+			+ "(#itemName != null ? #itemName.trim().replaceAll('\\s', '').toLowerCase().hashCode() : 'null') + '_' +"
+			+ " #cursor + '_' + #limit",
 		unless = "#result == null"
 	)
 	@Transactional(readOnly = true)

--- a/src/main/java/excluz/excluz/domain/store/storeSettlement/service/StoreSettlementV2Service.java
+++ b/src/main/java/excluz/excluz/domain/store/storeSettlement/service/StoreSettlementV2Service.java
@@ -25,15 +25,18 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class StoreSettlementV2Service {
 
-	private StoreSettlementRepository settlementRepository;
-	private StoreSettlementV2Repository settlementV2Repository;
-	private StoreRepository storeRepository;
+	private final StoreSettlementRepository settlementRepository;
+	private final StoreSettlementV2Repository settlementV2Repository;
+	private final StoreRepository storeRepository;
 
 	@Transactional(readOnly = true)
 	public StoreSettlementResponseDtoList getSettlementList(Integer storeId, Integer settlementId,
 		LocalDateTime startDate, LocalDateTime endDate, String periodStr, Integer page, Integer size
 	) {
-		RevenuePeriod period = RevenuePeriod.valueOfIgnoreCase(periodStr);
+		RevenuePeriod period = null;
+		if (periodStr != null) {
+			period = RevenuePeriod.valueOfIgnoreCase(periodStr);
+		}
 
 		List<StoreSettlementResponseDto> responseDtoList = settlementV2Repository.findByPeriod(
 			storeId, settlementId, startDate, endDate, period, page, size);

--- a/src/test/java/excluz/excluz/domain/store/item/service/ItemServiceTest.java
+++ b/src/test/java/excluz/excluz/domain/store/item/service/ItemServiceTest.java
@@ -297,7 +297,7 @@ class ItemServiceTest {
 			Pageable pageable = PageRequest.of(0, 20);
 			List<Item> itemList = Collections.singletonList(SharedData.ITEM2);
 			Page<Item> itemPage = new PageImpl<>(itemList, pageable, itemList.size());
-			when(itemRepository.findByPriceWithItemName(eq(pageable), anyInt(), anyInt(), anyString()))
+			when(itemRepository.findByPriceWithItemName(eq(pageable), anyInt(), anyInt(), anyString(), anyInt()))
 				.thenReturn(itemPage);
 			ItemListResponseDto itemListResponseDto = new ItemListResponseDto(SharedData.ITEM_ID1, SharedData.ITEM_NAME2, SharedData.PRICE2);
 
@@ -306,10 +306,10 @@ class ItemServiceTest {
 				given(ItemListResponseDto.from(any(Item.class))).willReturn(itemListResponseDto);
 
 				// when
-				GetItemListResponseDto actualResult = itemService.getItemList(pageable, 1000, 5000, SharedData.ITEM_NAME2);
+				GetItemListResponseDto actualResult = itemService.getItemList(pageable, 1000, 5000, SharedData.ITEM_NAME2, 1);
 
 				// then
-				verify(itemRepository).findByPriceWithItemName(eq(pageable), anyInt(), anyInt(),  anyString());
+				verify(itemRepository).findByPriceWithItemName(eq(pageable), anyInt(), anyInt(), anyString(), anyInt());
 
 				assertThat(actualResult).isNotNull();
 
@@ -325,14 +325,14 @@ class ItemServiceTest {
 			// given
 			Pageable pageable = PageRequest.of(0, 10);
 			Page<Item> emptyPage = Page.empty();
-			when(itemRepository.findByPriceWithItemName(eq(pageable), anyInt(), anyInt(), anyString())).thenReturn(
+			when(itemRepository.findByPriceWithItemName(eq(pageable), anyInt(), anyInt(), anyString(), anyInt())).thenReturn(
 				emptyPage);
 
 			// when
-			GetItemListResponseDto actualResult = itemService.getItemList(pageable, 1000, 5000, SharedData.ITEM_NAME2);
+			GetItemListResponseDto actualResult = itemService.getItemList(pageable, 1000, 5000, SharedData.ITEM_NAME2, 1);
 
 			// then
-			verify(itemRepository).findByPriceWithItemName(eq(pageable), anyInt(), anyInt(), anyString());
+			verify(itemRepository).findByPriceWithItemName(eq(pageable), anyInt(), anyInt(), anyString(), anyInt());
 
 			assertThat(actualResult).isNotNull();
 			assertThat(actualResult.getItemList().getTotalElements()).isEqualTo(0);
@@ -347,17 +347,17 @@ class ItemServiceTest {
 			Page<Item> itemPage = new PageImpl<>(itemList, pageable, itemList.size());
 			ItemListResponseDto itemListResponseDto = new ItemListResponseDto(SharedData.ITEM_ID1, SharedData.ITEM_NAME2, SharedData.PRICE1);
 
-			when(itemRepository.findByPriceWithItemName(eq(pageable), anyInt(), anyInt(), isNull())).thenReturn(
+			when(itemRepository.findByPriceWithItemName(eq(pageable), anyInt(), anyInt(), isNull(), anyInt())).thenReturn(
 				itemPage);
 
 			try (MockedStatic<ItemListResponseDto> mockedStatic = mockStatic(ItemListResponseDto.class)) {
 				given(ItemListResponseDto.from(any(Item.class))).willReturn(itemListResponseDto);
 
 				// when
-				GetItemListResponseDto actualResult = itemService.getItemList(pageable, 1000, 5000, null);
+				GetItemListResponseDto actualResult = itemService.getItemList(pageable, 1000, 5000, null, 1);
 
 				// then
-				verify(itemRepository).findByPriceWithItemName(eq(pageable), anyInt(), anyInt(), isNull());
+				verify(itemRepository).findByPriceWithItemName(eq(pageable), anyInt(), anyInt(), isNull(), anyInt());
 
 				assertThat(actualResult.getItemList().getTotalElements()).isEqualTo(itemList.size());
 			}


### PR DESCRIPTION
## 목적
- item 리스트 조회 메서드에 캐싱 적용
- 로깅 메세지 전송 서비스 수정

## 변경점
- getItemList에 캐싱을 적용했습니다. (V3 엔드포인트 생성)
- storeId로 item을 조회할 수 있도록 필터가 추가되었습니다. (V1, V2,  V3 모두 적용)
- 로깅 서비스에 메세지 특수문자를 처리하는 로직이 추가되었습니다. (특수문자로인한 발송 실패 문제 해결)