### PR TITLE
:sparkles: feat: Implement top 10, individual, and all-time store ranking retrieval

### DIFF
--- a/src/main/java/excluz/excluz/auth/config/SecurityConfig.java
+++ b/src/main/java/excluz/excluz/auth/config/SecurityConfig.java
@@ -82,7 +82,9 @@ public class SecurityConfig {
 					"/api/v1/streamers/{streamerId}",
 					// 이벤트
 					"/api/v1/events/applicants", // 이벤트 응모 및 조회(단, @RequestParam 코드가 맞을 때)
-					"/api/v1/events/applicants/{eventApplicantId}"
+					"/api/v1/events/applicants/{eventApplicantId}",
+					// 랭킹 조회(TOP10)
+					"/api/store-ranking/top10"
 					).permitAll()
 				.requestMatchers("/api/v1/admin/**").hasRole("ADMIN") // 관리자
 				.requestMatchers("/api/v1/users/**").hasRole("CUSTOMER") // 일반 회원

--- a/src/main/java/excluz/excluz/common/entity/StoreRanking.java
+++ b/src/main/java/excluz/excluz/common/entity/StoreRanking.java
@@ -47,12 +47,12 @@ public class StoreRanking {
 	)
 	private Store store;
 
-	// 매출 타입 (D, M, Y)
+	// 매출 타입 (DAY, MONTH, YEAR)
 	@Comment("매출 타입")
 	@Enumerated(EnumType.STRING)
 	private RevenuePeriod rankingPeriod;
 
-	// 랭킹 날짜
+	// 랭킹 날짜 (랭킹 기준 시작 날짜)
 	@LastModifiedDate
 	@Column(name = "rank_date", nullable = false)
 	private LocalDateTime rankDate;

--- a/src/main/java/excluz/excluz/common/entity/StoreRanking.java
+++ b/src/main/java/excluz/excluz/common/entity/StoreRanking.java
@@ -26,7 +26,8 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
-@EntityListeners(AuditingEntityListener.class) // @LastModifiedDate는 Spring Data JPA의 AuditingEntityListener를 활성화해야 적용됨
+//  @LastModifiedDate는 Spring Data JPA의 AuditingEntityListener를 활성화해야 적용됨
+@EntityListeners(AuditingEntityListener.class) // '마지막 수정 시간'을 자동으로 기록
 @Table(name="store_rankings")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class StoreRanking {
@@ -52,7 +53,7 @@ public class StoreRanking {
 	@Enumerated(EnumType.STRING)
 	private RevenuePeriod rankingPeriod;
 
-	// 랭킹 날짜 (랭킹 기준 시작 날짜)
+	// 랭킹 날짜 (랭킹이 갱신된 시점)
 	@LastModifiedDate
 	@Column(name = "rank_date", nullable = false)
 	private LocalDateTime rankDate;
@@ -70,15 +71,8 @@ public class StoreRanking {
 	public StoreRanking(Store store, RevenuePeriod rankingPeriod, Integer rankPosition, Long revenue) {
 		this.store = store;
 		this.rankingPeriod = rankingPeriod;
-		this.rankDate = LocalDateTime.now();
+		this.rankDate = LocalDateTime.now(); // 생성 or 업데이트 시간 기록
 		this.rankPosition = rankPosition;
 		this.revenue = revenue;
-	}
-
-	// 기존 랭킹 업데이트 메서드 추가
-	public void updateRank(Integer rankPosition, Long revenue) {
-		this.rankPosition = rankPosition;
-		this.revenue = revenue;
-		this.rankDate = LocalDateTime.now();
 	}
 }

--- a/src/main/java/excluz/excluz/common/exception/error/ErrorCode.java
+++ b/src/main/java/excluz/excluz/common/exception/error/ErrorCode.java
@@ -45,7 +45,7 @@ public enum ErrorCode {
 	SETTLEMENT_ALREADY_COMPLETED(HttpStatus.BAD_REQUEST, "정산이 완료된 건은 상태변경이 불가합니다."),
 
 	// 랭킹 관련 예외 코드
-	INVALID_YEAR_MONTH_FORMAT(HttpStatus.BAD_REQUEST, "유효하지 않은 연월 형식입니다."),
+	INVALID_DATE_FORMAT(HttpStatus.BAD_REQUEST, "유효하지 않은 날짜 형식입니다."),
 	ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
 	STORE_ID_REQUIRED(HttpStatus.BAD_REQUEST, "스토어 ID가 필요합니다."),
 

--- a/src/main/java/excluz/excluz/common/exception/error/ErrorCode.java
+++ b/src/main/java/excluz/excluz/common/exception/error/ErrorCode.java
@@ -44,6 +44,11 @@ public enum ErrorCode {
 	INVALID_SETTLEMENT_STATUS_TRANSITION(HttpStatus.BAD_REQUEST, "현재 상태 이전으로 변경할 수 없습니다."),
 	SETTLEMENT_ALREADY_COMPLETED(HttpStatus.BAD_REQUEST, "정산이 완료된 건은 상태변경이 불가합니다."),
 
+	// 랭킹 관련 예외 코드
+	INVALID_YEAR_MONTH_FORMAT(HttpStatus.BAD_REQUEST, "유효하지 않은 연월 형식입니다."),
+	ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
+	STORE_ID_REQUIRED(HttpStatus.BAD_REQUEST, "스토어 ID가 필요합니다."),
+
 	// 포인트 관련 예외 코드
 	POINT_NOT_FOUND(HttpStatus.NOT_FOUND, "포인트를 충전해주세요."),
 

--- a/src/main/java/excluz/excluz/domain/store/storeRanking/controller/StoreRankingController.java
+++ b/src/main/java/excluz/excluz/domain/store/storeRanking/controller/StoreRankingController.java
@@ -28,9 +28,8 @@ public class StoreRankingController {
 	private final StoreRankingService storeRankingService;
 	private final StoreRepository storeRepository;
 
-	// TOP 10 랭킹 조회 (매출 정보 제외)
-	// RequestParam value의 enum(DAY, MONTH, YEAR)에 따라 동적으로 조회 가능
-	// 요청 URL 예:
+	// TOP 10 랭킹 조회 (매출 정보 제외) | RequestParam value의 enum(DAY, MONTH, YEAR)에 따라 동적으로 조회 가능
+	// 요청 URL 예: /api/v1/store-ranking/top10?period=DAY
 	@GetMapping("/top10")
 	public ResponseEntity<StoreRankingTop10ResponseDtoList> getTop10StoreRankingList(
 		@RequestParam(value = "period", defaultValue = "DAY") String period// "period" 값, 기본은 "DAY"
@@ -45,7 +44,7 @@ public class StoreRankingController {
 
 	// 역대 랭킹 조회 (스트리머: 자신의 가게 | 관리자: 특정 가게)
 	// 요청 URL 예(스트리머): /api/v1/store-ranking/store/rankings?date=2025-03&period=MONTH&page=0&size=10
-	// 요청 URL 예(관리자): /api/v1/store-ranking/store/rankings?date=2025-03&period=MONTH&page=0&size=10
+	// 요청 URL 예(관리자): /api/v1/store-ranking/store/rankings?storeId=1&date=2025-03&period=MONTH&page=0&size=10
 	@GetMapping("/store/rankings")
 	@PreAuthorize("hasAnyRole('STREAMER', 'ADMIN')") // 스트리머 or 관리자만 접근 허용
 	public ResponseEntity<StoreRankingResponseDtoList> getStoreRankingList(
@@ -75,7 +74,11 @@ public class StoreRankingController {
 	}
 
 	// 역대 랭킹 조회(전체): 관리자가 모든 스토어의 랭킹 조회
-	// 요청 URL 예: /api/v1/store-ranking/all/rankings?date=2025-03-08&period=MONTH&page=0&size=10
+	/**
+	 * 	요청 URL 예시
+	 * 	1️⃣ "yyyy-MM-dd" 형식: /api/v1/store-ranking/all/rankings?date=2025-03-08&period=MONTH&page=0&size=10
+	 * 	2️⃣ "yyyy-MM" 형식:    /api/v1/store-ranking/all/rankings?date=2025-03&period=MONTH&page=0&size=10
+ 	 */
 	@GetMapping("/all/rankings")
 	@PreAuthorize("hasRole('ADMIN')") // 관리자만 접근 허용
 	public ResponseEntity<StoreRankingResponseDtoList> getAllStoreRankingList(

--- a/src/main/java/excluz/excluz/domain/store/storeRanking/controller/StoreRankingController.java
+++ b/src/main/java/excluz/excluz/domain/store/storeRanking/controller/StoreRankingController.java
@@ -74,6 +74,29 @@ public class StoreRankingController {
 		return new ResponseEntity<>(response, HttpStatus.OK);
 	}
 
+	// 역대 랭킹 조회(전체): 관리자가 모든 스토어의 랭킹 조회
+	// 요청 URL 예: /api/v1/store-ranking/all/rankings?date=2025-03-08&period=MONTH&page=0&size=10
+	@GetMapping("/all/rankings")
+	@PreAuthorize("hasRole('ADMIN')") // 관리자만 접근 허용
+	public ResponseEntity<StoreRankingResponseDtoList> getAllStoreRankingList(
+		@RequestParam(value = "date", required = false) String date, // "yyyy-MM-dd" 또는 "yyyy-MM"
+		@RequestParam(value = "period", defaultValue = "MONTH") String period, // "period" 값, 기본은 "MONTH"
+		@RequestParam(defaultValue = "0") Integer page, // 페이지 번호
+		@RequestParam(defaultValue = "10") Integer size // 페이지 크기 (한 페이지에 몇 개)
+	) {
+		// 날짜가 올바른 형식인지 확인
+		validateDate(date);
+
+		// period 문자열을 RevenuePeriod enum으로 변환
+		RevenuePeriod revenuePeriod = RevenuePeriod.valueOfIgnoreCase(period);
+
+		// 서비스에서 모든 가게의 순위 정보를 조회
+		StoreRankingResponseDtoList response = storeRankingService.getAllStoreRankingList(
+			revenuePeriod, date, page, size
+		);
+		return new ResponseEntity<>(response, HttpStatus.OK);
+	}
+
 	// targetStoreId 결정 로직 (개별 조회용)
 	// 사용자의 역할에 따라 어떤 가게를 조회할지 결정하는 메서드
 	private Integer resolveTargetStoreId(Integer userId, UserRole userRole, Integer storeId) {

--- a/src/main/java/excluz/excluz/domain/store/storeRanking/controller/StoreRankingController.java
+++ b/src/main/java/excluz/excluz/domain/store/storeRanking/controller/StoreRankingController.java
@@ -1,0 +1,37 @@
+package excluz.excluz.domain.store.storeRanking.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import excluz.excluz.domain.store.store.repository.StoreRepository;
+import excluz.excluz.domain.store.storeRanking.dto.response.StoreRankingTop10ResponseDtoList;
+import excluz.excluz.domain.store.storeRanking.service.StoreRankingService;
+import excluz.excluz.domain.store.storeRevenue.enums.RevenuePeriod;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/store-ranking")
+@RequiredArgsConstructor
+public class StoreRankingController {
+	private final StoreRankingService storeRankingService;
+	private final StoreRepository storeRepository;
+
+	// TOP 10 랭킹 조회 (매출 정보 제외)
+	// RequestParam value의 enum(DAY, MONTH, YEAR)에 따라 동적으로 조회 가능
+	// 요청 URL 예:
+	@GetMapping("/top10")
+	public ResponseEntity<StoreRankingTop10ResponseDtoList> getTop10StoreRankingList(
+		@RequestParam(value = "period", defaultValue = "DAY") String period// "period" 값, 기본은 "DAY"
+	) {
+		// 문자열 period를 대소문자 구분 없이 RevenuePeriod(enum)으로 변환
+		RevenuePeriod revenuePeriod = RevenuePeriod.valueOfIgnoreCase(period);
+
+		// 서비스로부터 TOP 10 순위 데이터를 받아옴
+		StoreRankingTop10ResponseDtoList response = storeRankingService.getTop10StoreRankingList(revenuePeriod);
+		return new ResponseEntity<>(response, HttpStatus.OK);
+	}
+}

--- a/src/main/java/excluz/excluz/domain/store/storeRanking/controller/StoreRankingController.java
+++ b/src/main/java/excluz/excluz/domain/store/storeRanking/controller/StoreRankingController.java
@@ -2,15 +2,23 @@ package excluz.excluz.domain.store.storeRanking.controller;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import excluz.excluz.auth.util.SecurityContextUtil;
+import excluz.excluz.common.exception.BadRequestException;
+import excluz.excluz.common.exception.ForbiddenException;
+import excluz.excluz.common.exception.NotFoundException;
+import excluz.excluz.common.exception.error.ErrorCode;
 import excluz.excluz.domain.store.store.repository.StoreRepository;
+import excluz.excluz.domain.store.storeRanking.dto.response.StoreRankingResponseDtoList;
 import excluz.excluz.domain.store.storeRanking.dto.response.StoreRankingTop10ResponseDtoList;
 import excluz.excluz.domain.store.storeRanking.service.StoreRankingService;
 import excluz.excluz.domain.store.storeRevenue.enums.RevenuePeriod;
+import excluz.excluz.domain.user.enums.UserRole;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -33,5 +41,66 @@ public class StoreRankingController {
 		// 서비스로부터 TOP 10 순위 데이터를 받아옴
 		StoreRankingTop10ResponseDtoList response = storeRankingService.getTop10StoreRankingList(revenuePeriod);
 		return new ResponseEntity<>(response, HttpStatus.OK);
+	}
+
+	// 역대 랭킹 조회 (스트리머: 자신의 가게 | 관리자: 특정 가게)
+	// 요청 URL 예(스트리머): /api/v1/store-ranking/store/rankings?date=2025-03&period=MONTH&page=0&size=10
+	// 요청 URL 예(관리자): /api/v1/store-ranking/store/rankings?date=2025-03&period=MONTH&page=0&size=10
+	@GetMapping("/store/rankings")
+	@PreAuthorize("hasAnyRole('STREAMER', 'ADMIN')") // 스트리머 or 관리자만 접근 허용
+	public ResponseEntity<StoreRankingResponseDtoList> getStoreRankingList(
+		@RequestParam(required = false) Integer storeId, // 관리자는 storeId 기입해야 함
+		@RequestParam(value = "date", required = false) String date, // "yyyy-MM-dd" 또는 "yyyy-MM"
+		@RequestParam(value = "period", defaultValue = "MONTH") String period, // "period" 값, 기본은 "MONTH"
+		@RequestParam(defaultValue = "0") Integer page, // 페이지 번호
+		@RequestParam(defaultValue = "10") Integer size // 페이지 크기 (한 페이지에 몇 개)
+	) {
+		// 날짜가 올바른 형식인지 확인
+		validateDate(date);
+
+		// period 문자열을 RevenuePeriod enum으로 변환
+		RevenuePeriod revenuePeriod = RevenuePeriod.valueOfIgnoreCase(period);
+		// 현재 로그인한 사용자의 ID와 역할을 가져옴
+		Integer userId = SecurityContextUtil.getUserOrStreamerId();
+		UserRole userRole = SecurityContextUtil.getUserRole();
+
+		// targetStoreId 결정 로직
+		Integer targetStoreId = resolveTargetStoreId(userId, userRole, storeId);
+
+		// 서비스에서 해당 가게의 순위 정보를 조회
+		StoreRankingResponseDtoList response = storeRankingService.getStoreRankingList(
+			targetStoreId, revenuePeriod, date, page, size
+		);
+		return new ResponseEntity<>(response, HttpStatus.OK);
+	}
+
+	// targetStoreId 결정 로직 (개별 조회용)
+	// 사용자의 역할에 따라 어떤 가게를 조회할지 결정하는 메서드
+	private Integer resolveTargetStoreId(Integer userId, UserRole userRole, Integer storeId) {
+		if (userRole == UserRole.STREAMER) {
+			// 스트리머는 자신의 가게만 조회 가능
+			return storeRepository.findStoreByStreamerIdAndNotDeleted(userId)
+				.orElseThrow(() -> new NotFoundException(ErrorCode.STORE_NOT_FOUND))
+				.getId();
+		} else if (userRole == UserRole.ADMIN) {
+			// 관리자는 storeId가 반드시 필요함
+			if (storeId == null) {
+				throw new BadRequestException(ErrorCode.STORE_ID_REQUIRED);
+			}
+			// 입력받은 storeId가 실제로 존재하는지 확인
+			storeRepository.findById(storeId)
+				.orElseThrow(() -> new NotFoundException(ErrorCode.STORE_NOT_FOUND));
+			return storeId;
+		} else {
+			throw new ForbiddenException(ErrorCode.ACCESS_DENIED);
+		}
+	}
+
+	// 날짜 형식 검증 메서드
+	private void validateDate(String date) {
+		if (date != null && !date.matches(
+			"\\d{4}-\\d{2}(-\\d{2})?")) { // "yyyy-MM" 또는 "yyyy-MM-dd" (?는 바로 앞의 그룹이 옵션(선택적) 이라는 뜻)
+			throw new BadRequestException(ErrorCode.INVALID_DATE_FORMAT);
+		}
 	}
 }

--- a/src/main/java/excluz/excluz/domain/store/storeRanking/dto/response/StoreRankingResponseDto.java
+++ b/src/main/java/excluz/excluz/domain/store/storeRanking/dto/response/StoreRankingResponseDto.java
@@ -1,0 +1,19 @@
+package excluz.excluz.domain.store.storeRanking.dto.response;
+
+import lombok.Getter;
+
+@Getter
+public class StoreRankingResponseDto {
+	private final Integer storeId; // 스토어 ID
+	private final String storeName; // 스토어 이름
+	private final Long revenue; // 총 매출
+	private final Integer rankPosition; // 순위
+
+	// 매개변수 4개 이하 -> 생성자 직접 작성
+	public StoreRankingResponseDto(Integer storeId, String storeName, Long revenue, Integer rankPosition) {
+		this.storeId = storeId;
+		this.storeName = storeName;
+		this.revenue = revenue;
+		this.rankPosition = rankPosition;
+	}
+}

--- a/src/main/java/excluz/excluz/domain/store/storeRanking/dto/response/StoreRankingResponseDtoList.java
+++ b/src/main/java/excluz/excluz/domain/store/storeRanking/dto/response/StoreRankingResponseDtoList.java
@@ -1,0 +1,17 @@
+package excluz.excluz.domain.store.storeRanking.dto.response;
+
+import java.util.List;
+
+import lombok.Getter;
+
+@Getter
+public class StoreRankingResponseDtoList {
+	private final List<StoreRankingResponseDto> rankingList; // 랭킹 리스트
+	private final Long totalCount; // 총 개수
+
+	// 매개변수 4개 이하 -> 생성자 직접 작성
+	public StoreRankingResponseDtoList(List<StoreRankingResponseDto> rankingList, Long totalCount) {
+		this.rankingList = rankingList;
+		this.totalCount = totalCount;
+	}
+}

--- a/src/main/java/excluz/excluz/domain/store/storeRanking/dto/response/StoreRankingTop10ResponseDto.java
+++ b/src/main/java/excluz/excluz/domain/store/storeRanking/dto/response/StoreRankingTop10ResponseDto.java
@@ -1,0 +1,17 @@
+package excluz.excluz.domain.store.storeRanking.dto.response;
+
+import lombok.Getter;
+
+@Getter
+public class StoreRankingTop10ResponseDto {
+	private final Integer storeId; // 스토어 ID
+	private final String storeName; // 스토어 이름
+	private final Integer rankPosition; // 순위
+
+	// 매개변수 4개 이하 -> 생성자 직접 작성
+	public StoreRankingTop10ResponseDto(Integer storeId, String storeName, Integer rankPosition) {
+		this.storeId = storeId;
+		this.storeName = storeName;
+		this.rankPosition = rankPosition;
+	}
+}

--- a/src/main/java/excluz/excluz/domain/store/storeRanking/dto/response/StoreRankingTop10ResponseDtoList.java
+++ b/src/main/java/excluz/excluz/domain/store/storeRanking/dto/response/StoreRankingTop10ResponseDtoList.java
@@ -1,0 +1,17 @@
+package excluz.excluz.domain.store.storeRanking.dto.response;
+
+import java.util.List;
+
+import lombok.Getter;
+
+@Getter
+public class StoreRankingTop10ResponseDtoList {
+	private final List<StoreRankingTop10ResponseDto> rankingList; // 랭킹 리스트
+	private final Long totalCount; // 총 개수
+
+	// 매개변수 4개 이하 -> 생성자 직접 작성
+	public StoreRankingTop10ResponseDtoList(List<StoreRankingTop10ResponseDto> rankingList, Long totalCount) {
+		this.rankingList = rankingList;
+		this.totalCount = totalCount;
+	}
+}

--- a/src/main/java/excluz/excluz/domain/store/storeRanking/repository/StoreRankingRepository.java
+++ b/src/main/java/excluz/excluz/domain/store/storeRanking/repository/StoreRankingRepository.java
@@ -35,4 +35,15 @@ public interface StoreRankingRepository extends JpaRepository<StoreRanking, Long
 		@Param("endDate") LocalDateTime endDate, // 검색 종료 날짜
 		Pageable pageable // 페이지 정보 (몇 번째 페이지, 몇 개씩)
 	);
+
+	// 전체 매장, 랭킹 기간, 날짜 범위에 맞는 정보 조회
+	// 주어진 period와 날짜 범위에 해당하는 모든 순위 데이터를 순위 오름차순(1등부터)으로 조회
+	@Query("SELECT sr FROM StoreRanking sr WHERE sr.rankingPeriod = :period AND "
+		+ "sr.rankDate BETWEEN :startDate AND :endDate ORDER BY sr.rankPosition ASC")
+	Page<StoreRanking> findByPeriodAndRankDateBetween(
+		@Param("period") RevenuePeriod period, // 조회할 랭킹 기간 (DAY, MONTH, YEAR)
+		@Param("startDate") LocalDateTime startDate, // 검색 시작 날짜
+		@Param("endDate") LocalDateTime endDate, // 검색 종료 날짜
+		Pageable pageable // 페이지 정보 (몇 번째 페이지, 몇 개씩)
+	);
 }

--- a/src/main/java/excluz/excluz/domain/store/storeRanking/repository/StoreRankingRepository.java
+++ b/src/main/java/excluz/excluz/domain/store/storeRanking/repository/StoreRankingRepository.java
@@ -1,5 +1,7 @@
 package excluz.excluz.domain.store.storeRanking.repository;
 
+import java.time.LocalDateTime;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -7,6 +9,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import excluz.excluz.common.entity.Store;
 import excluz.excluz.common.entity.StoreRanking;
 import excluz.excluz.domain.store.storeRevenue.enums.RevenuePeriod;
 
@@ -19,5 +22,17 @@ public interface StoreRankingRepository extends JpaRepository<StoreRanking, Long
 	Page<StoreRanking> findTop10ByRankingPeriod(
 		@Param("period") RevenuePeriod period, // 조회할 랭킹 기간 (DAY, MONTH, YEAR)
 		Pageable pageable // 페이지 정보 (여기서는 10개를 요청)
+	);
+
+	// 특정 매장, 랭킹 기간, 날짜 범위에 맞는 정보 조회
+	// 주어진 가게, period, 날짜 범위(startDate ~ endDate)에 해당하는 순위 데이터를 최근 순(날짜 내림차순)으로 조회
+	@Query("SELECT sr FROM StoreRanking sr WHERE sr.store = :store AND "
+		+ "sr.rankingPeriod = :period AND sr.rankDate BETWEEN :startDate AND :endDate ORDER BY sr.rankDate DESC")
+	Page<StoreRanking> findByStoreAndPeriodAndRankDateBetween(
+		@Param("store") Store store, // 조회할 가게
+		@Param("period") RevenuePeriod period, // 조회할 랭킹 기간 (DAY, MONTH, YEAR)
+		@Param("startDate") LocalDateTime startDate, // 검색 시작 날짜
+		@Param("endDate") LocalDateTime endDate, // 검색 종료 날짜
+		Pageable pageable // 페이지 정보 (몇 번째 페이지, 몇 개씩)
 	);
 }

--- a/src/main/java/excluz/excluz/domain/store/storeRanking/repository/StoreRankingRepository.java
+++ b/src/main/java/excluz/excluz/domain/store/storeRanking/repository/StoreRankingRepository.java
@@ -1,0 +1,23 @@
+package excluz.excluz.domain.store.storeRanking.repository;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import excluz.excluz.common.entity.StoreRanking;
+import excluz.excluz.domain.store.storeRevenue.enums.RevenuePeriod;
+
+@Repository
+public interface StoreRankingRepository extends JpaRepository<StoreRanking, Long> {
+	// TOP 10 랭킹 조회 (매출 정보 제외)
+	// 주어진 period에 대해 순위가 높은 순으로 10개의 기록만 조회
+	@Query("SELECT sr FROM StoreRanking sr WHERE sr.rankingPeriod = :period "
+		+ "ORDER BY sr.rankPosition ASC")
+	Page<StoreRanking> findTop10ByRankingPeriod(
+		@Param("period") RevenuePeriod period, // 조회할 랭킹 기간 (DAY, MONTH, YEAR)
+		Pageable pageable // 페이지 정보 (여기서는 10개를 요청)
+	);
+}

--- a/src/main/java/excluz/excluz/domain/store/storeRanking/service/StoreRankingService.java
+++ b/src/main/java/excluz/excluz/domain/store/storeRanking/service/StoreRankingService.java
@@ -66,6 +66,19 @@ public class StoreRankingService {
 		return new StoreRankingResponseDtoList(toDtoList(rankingPage), rankingPage.getTotalElements());
 	}
 
+
+	// 역대 랭킹 조회(전체): 관리자가 모든 스토어의 랭킹 조회
+	public StoreRankingResponseDtoList getAllStoreRankingList(RevenuePeriod revenuePeriod, String date, Integer page, Integer size) {
+		// 날짜 범위 계산
+		LocalDateTime[] range = getDateRange(revenuePeriod, date);
+
+		// 지정된 period와 날짜 범위에 해당하는 모든 순위 정보를 조회
+		Page<StoreRanking> rankingPage = storeRankingRepository.findByPeriodAndRankDateBetween(
+			revenuePeriod, range[0], range[1], PageRequest.of(page, size)
+		);
+		return new StoreRankingResponseDtoList(toDtoList(rankingPage), rankingPage.getTotalElements());
+	}
+
 	// 날짜 범위 계산 메서드
 	// "yyyy-MM-dd" 또는 "yyyy-MM" 형식의 문자열과 period에 따라 시작 시간과 종료 시간을 계산하여 배열로 반환
 	private LocalDateTime[] getDateRange(RevenuePeriod period, String date) {

--- a/src/main/java/excluz/excluz/domain/store/storeRanking/service/StoreRankingService.java
+++ b/src/main/java/excluz/excluz/domain/store/storeRanking/service/StoreRankingService.java
@@ -1,5 +1,8 @@
 package excluz.excluz.domain.store.storeRanking.service;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -8,8 +11,14 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import excluz.excluz.common.entity.Store;
 import excluz.excluz.common.entity.StoreRanking;
+import excluz.excluz.common.exception.BadRequestException;
+import excluz.excluz.common.exception.NotFoundException;
+import excluz.excluz.common.exception.error.ErrorCode;
 import excluz.excluz.domain.store.store.repository.StoreRepository;
+import excluz.excluz.domain.store.storeRanking.dto.response.StoreRankingResponseDto;
+import excluz.excluz.domain.store.storeRanking.dto.response.StoreRankingResponseDtoList;
 import excluz.excluz.domain.store.storeRanking.dto.response.StoreRankingTop10ResponseDto;
 import excluz.excluz.domain.store.storeRanking.dto.response.StoreRankingTop10ResponseDtoList;
 import excluz.excluz.domain.store.storeRanking.repository.StoreRankingRepository;
@@ -38,5 +47,78 @@ public class StoreRankingService {
 				r.getRankPosition()))
 			.collect(Collectors.toList());
 		return new StoreRankingTop10ResponseDtoList(list, rankingPage.getTotalElements());
+	}
+
+	// 역대 랭킹 조회 (스트리머: 자신의 가게 | 관리자: 특정 가게)
+	public StoreRankingResponseDtoList getStoreRankingList(Integer storeId, RevenuePeriod revenuePeriod, String date,
+		Integer page, Integer size) {
+		// storeId가 유효한지 확인 (가게가 존재하는지 체크) -> 필수 검증 한 번 더 수행
+		Store store = storeRepository.findById(storeId)
+			.orElseThrow(() -> new NotFoundException(ErrorCode.STORE_NOT_FOUND));
+
+		// 입력받은 날짜와 period 통해 조회할 날짜 범위 계산
+		LocalDateTime[] range = getDateRange(revenuePeriod, date);
+
+		// 해당 가게, period, 날짜 범위에 해당하는 순위 정보를 조회
+		Page<StoreRanking> rankingPage = storeRankingRepository.findByStoreAndPeriodAndRankDateBetween(
+			store, revenuePeriod, range[0], range[1], PageRequest.of(page, size)
+		);
+		return new StoreRankingResponseDtoList(toDtoList(rankingPage), rankingPage.getTotalElements());
+	}
+
+	// 날짜 범위 계산 메서드
+	// "yyyy-MM-dd" 또는 "yyyy-MM" 형식의 문자열과 period에 따라 시작 시간과 종료 시간을 계산하여 배열로 반환
+	private LocalDateTime[] getDateRange(RevenuePeriod period, String date) {
+		LocalDateTime now = LocalDateTime.now();
+		// "yyyy-MM-dd'T'HH:mm:ss" 형식의 포매터 (예: 2025-03-08T00:00:00)
+		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
+		LocalDateTime base;
+
+		// date가 없으면 현재 날짜 기준
+		if (date == null || date.isEmpty()) {
+			base = switch (period) {
+				case DAY -> now.truncatedTo(ChronoUnit.DAYS); // 오늘
+				case MONTH -> now.withDayOfMonth(1).truncatedTo(ChronoUnit.DAYS); // 이번 달 1일
+				case YEAR -> now.withDayOfYear(1).truncatedTo(ChronoUnit.DAYS); // 올해 1일
+			};
+		}
+		// "yyyy-MM-dd" 형식 (예: 2025-03-08)
+		else if (date.matches("\\d{4}-\\d{2}-\\d{2}")) {
+			base = LocalDateTime.parse(date + "T00:00:00", formatter);
+		}
+		// "yyyy-MM" 형식 (예: 2025-03)
+		else if (date.matches("\\d{4}-\\d{2}")) {
+			base = LocalDateTime.parse(date + "-01T00:00:00", formatter);
+		} else {
+			throw new BadRequestException(ErrorCode.INVALID_DATE_FORMAT);
+		}
+
+		// period에 따라 시작일과 종료일을 계산하여 배열로 반환
+		return switch (period) {
+			case DAY -> new LocalDateTime[] {
+				base.withHour(0).withMinute(0).withSecond(0), // 하루 시작 (00:00:00)
+				base.withHour(23).withMinute(59).withSecond(59) // 하루 끝 (23:59:59)
+			};
+			case MONTH -> new LocalDateTime[] {
+				base.withDayOfMonth(1).withHour(0).withMinute(0).withSecond(0), // 해당 달의 첫날 시작
+				base.plusMonths(1).minusSeconds(1) // 다음 달의 첫날 바로 전 초 (해당 달의 끝)
+			};
+			case YEAR -> new LocalDateTime[] {
+				base.withDayOfYear(1).withHour(0).withMinute(0).withSecond(0), // 해당 년도의 1일 시작
+				base.plusYears(1).minusSeconds(1) // 다음 해 1일 바로 전 초 (해당 년도의 끝)
+			};
+		};
+	}
+
+	// DTO 변환 메서드
+	// StoreRanking 엔티티 페이지를 StoreRankingResponseDto 리스트로 변환하는 메서드
+	private List<StoreRankingResponseDto> toDtoList(Page<StoreRanking> rankingPage) {
+		return rankingPage.getContent().stream()
+			.map(r -> new StoreRankingResponseDto(
+				r.getStore().getId(),
+				r.getStore().getStoreName(),
+				r.getRevenue(),
+				r.getRankPosition()))
+			.collect(Collectors.toList());
 	}
 }

--- a/src/main/java/excluz/excluz/domain/store/storeRanking/service/StoreRankingService.java
+++ b/src/main/java/excluz/excluz/domain/store/storeRanking/service/StoreRankingService.java
@@ -1,0 +1,42 @@
+package excluz.excluz.domain.store.storeRanking.service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import excluz.excluz.common.entity.StoreRanking;
+import excluz.excluz.domain.store.store.repository.StoreRepository;
+import excluz.excluz.domain.store.storeRanking.dto.response.StoreRankingTop10ResponseDto;
+import excluz.excluz.domain.store.storeRanking.dto.response.StoreRankingTop10ResponseDtoList;
+import excluz.excluz.domain.store.storeRanking.repository.StoreRankingRepository;
+import excluz.excluz.domain.store.storeRevenue.enums.RevenuePeriod;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class StoreRankingService {
+	private final StoreRankingRepository storeRankingRepository;
+	private final StoreRepository storeRepository;
+
+	// TOP 10 랭킹 조회 (매출 정보 제외)
+	public StoreRankingTop10ResponseDtoList getTop10StoreRankingList(RevenuePeriod period) {
+		// 리포지토리에서 지정된 period의 TOP 10 순위를 조회 (순위 오름차순 정렬)
+		Page<StoreRanking> rankingPage = storeRankingRepository.findTop10ByRankingPeriod(period, PageRequest.of(0, 10));
+		// 각 StoreRanking 엔티티를 StoreRankingTop10ResponseDto로 변환 (리스트)
+		List<StoreRankingTop10ResponseDto> list = rankingPage.getContent().stream()
+			.map(r -> new StoreRankingTop10ResponseDto(
+				r.getStore().getId(),
+				r.getStore().getStoreName(),
+				r.getRankPosition()))
+			.collect(Collectors.toList());
+		return new StoreRankingTop10ResponseDtoList(list, rankingPage.getTotalElements());
+	}
+}


### PR DESCRIPTION
## 목적
사용자가 다양한 기준(Top 10, 개별 스토어, 전체 스토어)으로 스토어 랭킹을 조회할 수 있도록 기능을 추가함.

## 변경점
- Top 10 스토어 랭킹 조회 기능 구현
   - RevenuePeriod(DAY, MONTH, YEAR) 기준으로 조회 가능
   - 매출 정보를 제외한 순위 데이터만 제공
   - 로그인 없이 접근 가능

- 개별 스토어 역대 랭킹 조회 기능 구현
   - 스트리머: 자신의 스토어 랭킹만 조회 가능
   - 관리자: 특정 storeId를 입력하여 조회 가능

- 모든 스토어 역대 랭킹 조회 기능 구현
   - 관리자 전용 API
   - 전체 스토어의 특정 기간(일, 월, 년) 랭킹을 조회 가능

- ErrorCode 수정: 날짜 형식 검증을 위한 INVALID_DATE_FORMAT 추가
- SecurityConfig 수정: Top 10 조회 API는 로그인 없이 접근 가능하도록 설정