### PR TITLE
✨ feat: Implement duplicate check logic

### DIFF
--- a/src/main/java/excluz/excluz/common/exception/error/ErrorCode.java
+++ b/src/main/java/excluz/excluz/common/exception/error/ErrorCode.java
@@ -17,6 +17,8 @@ public enum ErrorCode {
 	INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "이전과 동일한 비밀번호로 수정할 수 없습니다."),
 	PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
 	EMAIL_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 사용중인 이메일입니다."),
+	PHONE_NUMBER_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 사용중인 전화번호입니다."),
+	NICKNAME_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 사용중인 닉네임입니다."),
 	PASSWORD_RE_ENTER_PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "비밀번호와 재입력 비밀번호가 일치하지 않습니다."),
 	FAIL_SEND_EMAIL(HttpStatus.BAD_REQUEST, "인증 코드 발송에 실패하였습니다."),
 	EMAIL_VERIFICATION_NOT_REQUESTED(HttpStatus.BAD_REQUEST, "이메일 인증을 먼저 진행해 주세요"),

--- a/src/main/java/excluz/excluz/domain/streamer/repository/StreamerRepository.java
+++ b/src/main/java/excluz/excluz/domain/streamer/repository/StreamerRepository.java
@@ -20,5 +20,11 @@ public interface StreamerRepository extends JpaRepository<Streamer, Integer> {
 		"WHERE (:nickName IS NULL OR s.nickName LIKE concat('%', :nickName , '%')) " +
 		"AND s.isDeleted=false " +
 		"ORDER BY s.id DESC")
-	Page<Streamer> findByNickName(Pageable pageable, @Param("nickName") String nickName);
+	Page<Streamer> findStreamersByNickName(Pageable pageable, @Param("nickName") String nickName);
+
+	@Query("SELECT s FROM Streamer s WHERE (s.phoneNumber LIKE :phoneNumber) AND s.isDeleted=false")
+	Optional<Streamer> findByPhoneNumber(@Param("phoneNumber") String phoneNumber);
+
+	@Query("SELECT s FROM Streamer s WHERE (s.nickName LIKE :nickName) AND s.isDeleted=false")
+	Optional<Streamer> findByNickName(@Param("nickName") String nickName);
 }

--- a/src/main/java/excluz/excluz/domain/streamer/service/StreamerService.java
+++ b/src/main/java/excluz/excluz/domain/streamer/service/StreamerService.java
@@ -34,6 +34,8 @@ public class StreamerService {
 
 	@Transactional
 	public StreamerResponseDto streamerSignup(StreamerSignupRequestDto signupRequestDto) {
+		validateStreamerSignupInfo(signupRequestDto);
+
 		if (!signupRequestDto.getPassword().equals(signupRequestDto.getReEnterPassword())) {
 			throw new BadRequestException(ErrorCode.PASSWORD_MISMATCH);
 		}
@@ -57,6 +59,21 @@ public class StreamerService {
 			.build();
 
 		return StreamerResponseDto.from(streamerRepository.save(streamer));
+	}
+
+	private void validateStreamerSignupInfo(StreamerSignupRequestDto signupRequestDto) {
+		// 비즈니스 규칙: 탈퇴 후 동일한 이메일로 재가입 불가.
+		if (streamerRepository.findByEmail(signupRequestDto.getEmail()).isPresent()) {
+			throw new BadRequestException(ErrorCode.EMAIL_ALREADY_EXISTS);
+		}
+
+		if (streamerRepository.findByPhoneNumber(signupRequestDto.getPhoneNumber()).isPresent()) {
+			throw new BadRequestException(ErrorCode.PHONE_NUMBER_ALREADY_EXISTS);
+		}
+
+		if (streamerRepository.findByNickName(signupRequestDto.getNickName()).isPresent()) {
+			throw new BadRequestException(ErrorCode.NICKNAME_ALREADY_EXISTS);
+		}
 	}
 
 	public StreamerLoginResponseDto streamerLogin(StreamerLoginRequestDto loginRequestDto) {
@@ -117,7 +134,7 @@ public class StreamerService {
 	public Page<StreamerSummaryResponseDto> getStreamerList(int page, int size, String nickName) {
 		Pageable pageable = PageRequest.of(Math.max(page, 0), size);
 
-		Page<Streamer> streamerList = streamerRepository.findByNickName(pageable, nickName);
+		Page<Streamer> streamerList = streamerRepository.findStreamersByNickName(pageable, nickName);
 
 		return streamerList.map(StreamerSummaryResponseDto::from);
 	}

--- a/src/main/java/excluz/excluz/domain/user/repository/UserRepository.java
+++ b/src/main/java/excluz/excluz/domain/user/repository/UserRepository.java
@@ -18,5 +18,5 @@ public interface UserRepository extends JpaRepository<User, Integer> {
 	Optional<User> findByNickName(@Param("nickName") String nickName);
 
 	@Query("SELECT u FROM User u WHERE (u.phoneNumber LIKE :phoneNumber) AND u.isDeleted=false")
-	Optional<Streamer> findByPhoneNumber(@Param("phoneNumber") String phoneNumber);
+	Optional<User> findByPhoneNumber(@Param("phoneNumber") String phoneNumber);
 }

--- a/src/main/java/excluz/excluz/domain/user/repository/UserRepository.java
+++ b/src/main/java/excluz/excluz/domain/user/repository/UserRepository.java
@@ -3,9 +3,20 @@ package excluz.excluz.domain.user.repository;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import excluz.excluz.common.entity.Streamer;
 import excluz.excluz.common.entity.User;
+import jakarta.validation.constraints.NotBlank;
 
 public interface UserRepository extends JpaRepository<User, Integer> {
 
 	Optional<User> findByEmail(String email);
+
+	@Query("SELECT u FROM User u WHERE (u.nickName LIKE :nickName) AND u.isDeleted=false")
+	Optional<User> findByNickName(@Param("nickName") String nickName);
+
+	@Query("SELECT u FROM User u WHERE (u.phoneNumber LIKE :phoneNumber) AND u.isDeleted=false")
+	Optional<Streamer> findByPhoneNumber(@Param("phoneNumber") String phoneNumber);
 }

--- a/src/main/java/excluz/excluz/domain/user/service/UserService.java
+++ b/src/main/java/excluz/excluz/domain/user/service/UserService.java
@@ -38,8 +38,15 @@ public class UserService {
 
 	// 유저 회원가입
 	public UserSignupResponseDto userSignup(UserSignupRequestDto signupRequest) {
+		if (userRepository.findByNickName(signupRequest.getNickName()).isPresent()) {
+			throw new BadRequestException(ErrorCode.NICKNAME_ALREADY_EXISTS);
+		}
 
-		// 가입된 유저의 이메일 여부를 확인
+		if (userRepository.findByPhoneNumber(signupRequest.getPhoneNumber()).isPresent()) {
+			throw new BadRequestException(ErrorCode.PHONE_NUMBER_ALREADY_EXISTS);
+		}
+
+		// 가입된 유저의 이메일 여부를 확인 (비즈니스 규칙: 탈퇴한 이메일로 재가입 불가능)
 		Optional<User> existingUser = userRepository.findByEmail(signupRequest.getEmail());
 
 		// Oauth 소셜 로그인을 진행했을때 로그인된 이메일과 소셜 로그인 연동을 처리한다. 소셜 로그인이 연동 되어있는 경우에만 메일 발송


### PR DESCRIPTION
## 목표
유저, 스트리머 회원가입 시 중복된 가입 정보에 대한 예외처리 추가

## 변경점
- 유저, 스트리머 회원가입 시 중복된 이메일, 전화번호, 닉네임에 대한 예외처리를 추가함
- 비즈니스 규칙상 탈퇴한 이메일로 재가입 불가능하도록 설정
- 전화번호, 닉네임의 경우 탈퇴한 정보 재사용 가능하도록 함